### PR TITLE
#113 feat: 대시보드 페이지 API 연동

### DIFF
--- a/src/components/Button/GrayButton90.jsx
+++ b/src/components/Button/GrayButton90.jsx
@@ -23,10 +23,11 @@ export const GrayButton90 = styled.button`
   color: #ffffff;
   font-weight: 600;
   font-size: 14px;
-  transition:
-    background 0.3s ease,
-    box-shadow 0.3s ease,
-    transform 0.3s ease;
+  transition: background 0.3s ease-in-out;
+
+  &:hover {
+    background: #a8b0b6;
+  }
 
   &:disabled {
     background: var(--gray-200, #d9d9d9);

--- a/src/components/Button/GrayButton90.jsx
+++ b/src/components/Button/GrayButton90.jsx
@@ -28,7 +28,6 @@ export const GrayButton90 = styled.button`
   &:hover {
     background-color: var(--gray-300, #636363);
     color: #fff;
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
   }
 
   &:disabled {

--- a/src/components/Button/GrayButton90.jsx
+++ b/src/components/Button/GrayButton90.jsx
@@ -26,7 +26,9 @@ export const GrayButton90 = styled.button`
   transition: background 0.3s ease-in-out;
 
   &:hover {
-    background: #a8b0b6;
+    background-color: var(--gray-300, #636363);
+    color: #fff;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
   }
 
   &:disabled {

--- a/src/pages/DashboardPage/DashboardPage.jsx
+++ b/src/pages/DashboardPage/DashboardPage.jsx
@@ -13,6 +13,7 @@ import { useNavigate } from 'react-router-dom';
 export default function DashboardPage() {
   const [copyMessage, setCopyMessage] = useState('');
   const [parsedEvents, setParsedEvents] = useState(null);
+  const [averageAttendance, setAverageAttendance] = useState(0);
   const [completedSessions, setCompletedSessions] = useState(0);
   const EVENT_ID = useRecoilValue(eventIDState);
   const navigate = useNavigate();
@@ -41,17 +42,32 @@ export default function DashboardPage() {
               date: schedule.eventDate,
               startTime: schedule.eventStartTime,
               endTime: schedule.eventEndTime,
+              attendanceList: schedule.attendanceListResponseDtos,
             };
           });
+
+          const totalAttendance = schedules.reduce((acc, schedule) => {
+            const attendedCount = schedule.attendanceList.filter(
+              (attendee) => attendee.attendance,
+            ).length;
+            return acc + attendedCount;
+          }, 0);
+
+          const totalParticipants = schedules[0].attendanceList.length;
+          const averageAttendance = totalParticipants
+            ? (totalAttendance / schedules.length).toFixed(1)
+            : 0;
 
           const parsedEvent = {
             title: eventData.eventTitle,
             detail: eventData.eventDetail,
             schedules,
             totalSessions: eventData.eventSchedules.length,
+            totalParticipants,
           };
 
           setParsedEvents(parsedEvent);
+          setAverageAttendance(averageAttendance);
           setCompletedSessions(completedSessionsCount);
         }
       } catch (error) {
@@ -170,7 +186,9 @@ export default function DashboardPage() {
                 </S.ProgressIcon>
                 <S.ProgressContentWrapper>
                   <S.ProgressTitle>평균 참석 인원</S.ProgressTitle>
-                  <S.ProgressText>0 / 30</S.ProgressText>
+                  <S.ProgressText>
+                    {averageAttendance} / {parsedEvents.totalParticipants}
+                  </S.ProgressText>
                 </S.ProgressContentWrapper>
               </S.ProgressBox>
 

--- a/src/pages/DashboardPage/DashboardPage.jsx
+++ b/src/pages/DashboardPage/DashboardPage.jsx
@@ -153,7 +153,7 @@ export default function DashboardPage() {
                     <S.EventDateWrapper>
                       {parsedEvents.schedules.map((schedule, index) => (
                         <S.EventDate key={index}>
-                          {`${schedule.date} (${schedule.startTime} - ${schedule.endTime})`}
+                          {`• ${schedule.date} (${schedule.startTime} - ${schedule.endTime})`}
                         </S.EventDate>
                       ))}
                     </S.EventDateWrapper>

--- a/src/pages/DashboardPage/DashboardPage.jsx
+++ b/src/pages/DashboardPage/DashboardPage.jsx
@@ -12,26 +12,44 @@ import { useNavigate } from 'react-router-dom';
 
 export default function DashboardPage() {
   const [copyMessage, setCopyMessage] = useState('');
+  const [parsedEvents, setParsedEvents] = useState(null);
   const EVENT_ID = useRecoilValue(eventIDState);
   const navigate = useNavigate();
 
   useEffect(() => {
-    if (copyMessage) {
-      const timer = setTimeout(() => {
-        setCopyMessage('');
-      }, 3000);
-      return () => clearTimeout(timer);
-    }
-  }, [copyMessage]);
+    console.log('USER_ID:', USER_ID);
+    console.log('EVENT_ID:', EVENT_ID);
+    const fetchData = async () => {
+      try {
+        const response = await axiosInstance.get(
+          `/api/v1/events/${USER_ID}/${EVENT_ID}`,
+        );
+        const eventData = response.data;
+        if (eventData) {
+          const parsedEvent = {
+            title: eventData.eventTitle,
+            detail: eventData.eventDetail,
+          };
+          setParsedEvents(parsedEvent);
+        }
+      } catch (error) {
+        console.error('Error fetching event data:', error);
+      }
+    };
+
+    fetchData();
+  }, [EVENT_ID]);
 
   const handleCopy = (text) => {
     navigator.clipboard
       .writeText(text)
       .then(() => {
         setCopyMessage('링크가 복사되었습니다!');
+        setTimeout(() => setCopyMessage(''), 3000);
       })
       .catch((err) => {
         setCopyMessage('복사에 실패했습니다. 다시 시도해주세요.');
+        setTimeout(() => setCopyMessage(''), 3000);
         console.error('복사 실패:', err);
       });
   };
@@ -58,89 +76,91 @@ export default function DashboardPage() {
 
   return (
     <PageLayout sideBar={<Sidebar />}>
-      <S.DashboardPage>
-        {copyMessage && <S.CopyMessage>{copyMessage}</S.CopyMessage>}
-        <S.TopContainer>
-          <S.EventTitle>체크메이트 해커톤</S.EventTitle>
-          <S.ButtonContainer>
-            <S.StyledLink to="/event/dashboard/info">
-              <GrayButton90>행사 수정</GrayButton90>
-            </S.StyledLink>
-            <S.DeleteEventButton onClick={DeleteEvent}>
-              행사 삭제
-            </S.DeleteEventButton>
-          </S.ButtonContainer>
-        </S.TopContainer>
+      {parsedEvents && (
+        <S.DashboardPage>
+          {copyMessage && <S.CopyMessage>{copyMessage}</S.CopyMessage>}
+          <S.TopContainer>
+            <S.EventTitle>{parsedEvents.title}</S.EventTitle>
+            <S.ButtonContainer>
+              <S.StyledLink to="/event/dashboard/info">
+                <GrayButton90>행사 수정</GrayButton90>
+              </S.StyledLink>
+              <S.DeleteEventButton onClick={DeleteEvent}>
+                행사 삭제
+              </S.DeleteEventButton>
+            </S.ButtonContainer>
+          </S.TopContainer>
 
-        {/* 행사 정보 */}
-        <S.ContentContainer>
-          <S.OverviewContainer>
-            <S.ContentBox>
-              <S.ContentTitle>QR 코드</S.ContentTitle>
-              <S.QrCode>
-                <img
-                  src="https://www.google.com/url?sa=i&url=http%3A%2F%2Ft3.gstatic.com%2Flicensed-image%3Fq%3Dtbn%3AANd9GcSh-wrQu254qFaRcoYktJ5QmUhmuUedlbeMaQeaozAVD4lh4ICsGdBNubZ8UlMvWjKC&psig=AOvVaw3Zwwv5QaquDAu22BSpbs0n&ust=1720330468548000&source=images&cd=vfe&opi=89978449&ved=0CAkQjRxqFwoTCMijksXYkYcDFQAAAAAdAAAAABAE"
-                  alt=""
-                />
-              </S.QrCode>
-            </S.ContentBox>
-
-            <S.OverviewWrapper>
+          {/* 행사 정보 */}
+          <S.ContentContainer>
+            <S.OverviewContainer>
               <S.ContentBox>
-                <S.ContentTitle>행사 개요</S.ContentTitle>
-                <S.ContentInfoWrapper>
-                  <S.EventTypeWrapper>
-                    <S.EventType>오프라인 행사</S.EventType>
-                    <S.EventVenue>캠퍼스 내부</S.EventVenue>
-                  </S.EventTypeWrapper>
-                  <S.EventDateWrapper>
-                    <S.EventDate>7월 11일 오전 10:00</S.EventDate>
-                  </S.EventDateWrapper>
-                </S.ContentInfoWrapper>
+                <S.ContentTitle>QR 코드</S.ContentTitle>
+                <S.QrCode>
+                  <img
+                    src="https://www.google.com/url?sa=i&url=http%3A%2F%2Ft3.gstatic.com%2Flicensed-image%3Fq%3Dtbn%3AANd9GcSh-wrQu254qFaRcoYktJ5QmUhmuUedlbeMaQeaozAVD4lh4ICsGdBNubZ8UlMvWjKC&psig=AOvVaw3Zwwv5QaquDAu22BSpbs0n&ust=1720330468548000&source=images&cd=vfe&opi=89978449&ved=0CAkQjRxqFwoTCMijksXYkYcDFQAAAAAdAAAAABAE"
+                    alt=""
+                  />
+                </S.QrCode>
               </S.ContentBox>
-              <S.ContentBox>
-                <S.ContentTitle>담당자</S.ContentTitle>
-                <S.ContentInfoWrapper>
-                  <S.ContentText>010-1234-5678</S.ContentText>
-                  <S.ContentText>checkmate@sookmyung.ac.kr</S.ContentText>
-                </S.ContentInfoWrapper>
-              </S.ContentBox>
-              <S.ContentBox>
-                <S.ContentTitle>설문조사 링크</S.ContentTitle>
-                <S.ContentTextWrapper>
-                  <S.ContentText>naver.com</S.ContentText>
-                  <S.CopyBtn onClick={() => handleCopy('naver.com')}>
-                    복사하기
-                  </S.CopyBtn>
-                </S.ContentTextWrapper>
-              </S.ContentBox>
-            </S.OverviewWrapper>
-          </S.OverviewContainer>
 
-          {/* 진행 현황 */}
-          <S.ProgressContainer>
-            <S.ProgressBox>
-              <S.ProgressIcon>
-                <FaUsers />
-              </S.ProgressIcon>
-              <S.ProgressContentWrapper>
-                <S.ProgressTitle>전체 참석률</S.ProgressTitle>
-                <S.ProgressText>0 / 30</S.ProgressText>
-              </S.ProgressContentWrapper>
-            </S.ProgressBox>
+              <S.OverviewWrapper>
+                <S.ContentBox>
+                  <S.ContentTitle>행사 개요</S.ContentTitle>
+                  <S.ContentInfoWrapper>
+                    <S.EventTypeWrapper>
+                      <S.EventType>오프라인 행사</S.EventType>
+                      <S.EventVenue>캠퍼스 내부</S.EventVenue>
+                    </S.EventTypeWrapper>
+                    <S.EventDateWrapper>
+                      <S.EventDate>7월 11일 오전 10:00</S.EventDate>
+                    </S.EventDateWrapper>
+                  </S.ContentInfoWrapper>
+                </S.ContentBox>
+                <S.ContentBox>
+                  <S.ContentTitle>담당자</S.ContentTitle>
+                  <S.ContentInfoWrapper>
+                    <S.ContentText>010-1234-5678</S.ContentText>
+                    <S.ContentText>checkmate@sookmyung.ac.kr</S.ContentText>
+                  </S.ContentInfoWrapper>
+                </S.ContentBox>
+                <S.ContentBox>
+                  <S.ContentTitle>설문조사 링크</S.ContentTitle>
+                  <S.ContentTextWrapper>
+                    <S.ContentText>naver.com</S.ContentText>
+                    <S.CopyBtn onClick={() => handleCopy('naver.com')}>
+                      복사하기
+                    </S.CopyBtn>
+                  </S.ContentTextWrapper>
+                </S.ContentBox>
+              </S.OverviewWrapper>
+            </S.OverviewContainer>
 
-            <S.ProgressBox>
-              <S.ProgressIcon>
-                <FaRotate />
-              </S.ProgressIcon>
-              <S.ProgressContentWrapper>
-                <S.ProgressTitle>진행 회차</S.ProgressTitle>
-                <S.ProgressText>0 / 3</S.ProgressText>
-              </S.ProgressContentWrapper>
-            </S.ProgressBox>
-          </S.ProgressContainer>
-        </S.ContentContainer>
-      </S.DashboardPage>{' '}
+            {/* 진행 현황 */}
+            <S.ProgressContainer>
+              <S.ProgressBox>
+                <S.ProgressIcon>
+                  <FaUsers />
+                </S.ProgressIcon>
+                <S.ProgressContentWrapper>
+                  <S.ProgressTitle>전체 참석률</S.ProgressTitle>
+                  <S.ProgressText>0 / 30</S.ProgressText>
+                </S.ProgressContentWrapper>
+              </S.ProgressBox>
+
+              <S.ProgressBox>
+                <S.ProgressIcon>
+                  <FaRotate />
+                </S.ProgressIcon>
+                <S.ProgressContentWrapper>
+                  <S.ProgressTitle>진행 회차</S.ProgressTitle>
+                  <S.ProgressText>0 / 3</S.ProgressText>
+                </S.ProgressContentWrapper>
+              </S.ProgressBox>
+            </S.ProgressContainer>
+          </S.ContentContainer>
+        </S.DashboardPage>
+      )}
     </PageLayout>
   );
 }

--- a/src/pages/DashboardPage/DashboardPage.jsx
+++ b/src/pages/DashboardPage/DashboardPage.jsx
@@ -4,9 +4,16 @@ import React, { useState, useEffect } from 'react';
 import PageLayout from '../../Layout/PageLayout';
 import { Sidebar } from '../../components/Navigator';
 import { GrayButton90 } from '../../components/Button';
+import { eventIDState } from '../../recoil/atoms/state';
+import { useRecoilValue } from 'recoil';
+import { USER_ID } from '../../constants';
+import { axiosInstance } from '../../axios';
+import { useNavigate } from 'react-router-dom';
 
 export default function DashboardPage() {
   const [copyMessage, setCopyMessage] = useState('');
+  const EVENT_ID = useRecoilValue(eventIDState);
+  const navigate = useNavigate();
 
   useEffect(() => {
     if (copyMessage) {
@@ -29,19 +36,42 @@ export default function DashboardPage() {
       });
   };
 
+  const DeleteEvent = async () => {
+    const isConfirmed = window.confirm('행사를 완전히 삭제하시겠습니까?');
+    if (!isConfirmed) {
+      return;
+    }
+    try {
+      const response = await axiosInstance.delete(
+        `api/v1/events/${USER_ID}/${EVENT_ID}`,
+      );
+      if (response.status === 200) {
+        alert('행사가 삭제되었습니다. 목록 페이지로 이동합니다.');
+        navigate('/event');
+        console.log(response);
+      }
+    } catch (error) {
+      alert('행사 삭제에 실패했습니다. 다시 시도해 주세요.');
+      console.log(error);
+    }
+  };
+
   return (
     <PageLayout sideBar={<Sidebar />}>
       <S.DashboardPage>
-        {copyMessage && <S.CopyMessage>{copyMessage}</S.CopyMessage>}{' '}
+        {copyMessage && <S.CopyMessage>{copyMessage}</S.CopyMessage>}
         <S.TopContainer>
           <S.EventTitle>체크메이트 해커톤</S.EventTitle>
           <S.ButtonContainer>
             <S.StyledLink to="/event/dashboard/info">
               <GrayButton90>행사 수정</GrayButton90>
             </S.StyledLink>
-            <GrayButton90>행사 삭제</GrayButton90>
+            <S.DeleteEventButton onClick={DeleteEvent}>
+              행사 삭제
+            </S.DeleteEventButton>
           </S.ButtonContainer>
         </S.TopContainer>
+
         {/* 행사 정보 */}
         <S.ContentContainer>
           <S.OverviewContainer>

--- a/src/pages/DashboardPage/DashboardPage.jsx
+++ b/src/pages/DashboardPage/DashboardPage.jsx
@@ -29,6 +29,11 @@ export default function DashboardPage() {
           const parsedEvent = {
             title: eventData.eventTitle,
             detail: eventData.eventDetail,
+            schedules: eventData.eventSchedules.map((schedule) => ({
+              date: schedule.eventDate,
+              startTime: schedule.eventStartTime,
+              endTime: schedule.eventEndTime,
+            })),
           };
           setParsedEvents(parsedEvent);
         }
@@ -113,7 +118,11 @@ export default function DashboardPage() {
                       <S.EventVenue>캠퍼스 내부</S.EventVenue>
                     </S.EventTypeWrapper>
                     <S.EventDateWrapper>
-                      <S.EventDate>7월 11일 오전 10:00</S.EventDate>
+                      {parsedEvents.schedules.map((schedule, index) => (
+                        <S.EventDate key={index}>
+                          {`${schedule.date}  (${schedule.startTime} - ${schedule.endTime})`}
+                        </S.EventDate>
+                      ))}
                     </S.EventDateWrapper>
                   </S.ContentInfoWrapper>
                 </S.ContentBox>

--- a/src/pages/DashboardPage/DashboardPage.style.jsx
+++ b/src/pages/DashboardPage/DashboardPage.style.jsx
@@ -162,10 +162,13 @@ export const EventVenue = styled.p`
 
 export const EventDateWrapper = styled.div`
   display: flex;
+  flex-direction: column;
+  gap: 6px;
 `;
 
 export const EventDate = styled.p`
   font-size: 14px;
+  color: var(--gray-300, #636363);
 `;
 
 export const QrCode = styled.div`

--- a/src/pages/DashboardPage/DashboardPage.style.jsx
+++ b/src/pages/DashboardPage/DashboardPage.style.jsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import { Link } from 'react-router-dom';
+import { GrayButton90 } from '../../components';
 
 export const DashboardPage = styled.div`
   flex-grow: 1;
@@ -17,6 +18,54 @@ export const TopContainer = styled.div`
 export const ButtonContainer = styled.div`
   display: flex;
   gap: 10px;
+`;
+
+export const DeleteEventButton = styled(GrayButton90)`
+  box-sizing: border-box;
+  position: relative;
+  display: inline-block;
+  transition:
+    background-color 0.3s ease-in-out,
+    color 0.3s ease-in-out,
+    box-shadow 0.3s ease-in-out;
+
+  &:hover::after {
+    content: '삭제된 행사는 복구할 수 없습니다.';
+    position: absolute;
+    top: 100%;
+    right: 0;
+    margin-top: 10px;
+    padding: 5px;
+    background-color: #333;
+    color: #fff;
+    border-radius: 4px;
+    white-space: nowrap;
+    font-size: 12px;
+    z-index: 1;
+    opacity: 1;
+    visibility: visible;
+    transition:
+      opacity 0.2s ease-in-out,
+      visibility 0.2s ease-in-out;
+  }
+
+  &:hover::before {
+    content: '';
+    position: absolute;
+    top: 100%;
+    right: 50%;
+    transform: translateX(50%);
+    margin-bottom: 5px;
+    border-width: 6px;
+    border-style: solid;
+    border-color: transparent transparent #333 transparent;
+    z-index: 1;
+    opacity: 1;
+    visibility: visible;
+    transition:
+      opacity 0.2s ease-in-out,
+      visibility 0.2s ease-in-out;
+  }
 `;
 
 export const StyledLink = styled(Link)`


### PR DESCRIPTION
## #️⃣ 관련 이슈

#113

## 📝 작업 내용

- 행사 타이틀 API 연동
- 행사 개요 내 행사 일정 API 연동
- 평균 참석 인원 및 진행 회차 API 연동
- 행사 삭제 API 연동

## 📸 스크린샷
![image](https://github.com/user-attachments/assets/0f6ccf4c-963b-4f84-8c85-ed28c046ec1a)
