### PR TITLE
#113 feat: 행사 기본 정보에 데이터 불러오는 API 연동

### DIFF
--- a/src/pages/DashboardPage/DashboardInfoPage.jsx
+++ b/src/pages/DashboardPage/DashboardInfoPage.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import * as S from './DashboardInfoPage.style';
-import { FaAngleRight, FaRegTrashCan } from 'react-icons/fa6';
+import { FaAngleRight, FaRegTrashCan, FaCircleInfo } from 'react-icons/fa6';
 import { Sidebar } from '../../components/Navigator';
 import { BlueButton90 } from '../../components/Button';
 import { USER_ID } from '../../constants';
@@ -252,7 +252,9 @@ export default function DashboardInfoPage() {
                   />
                 </S.DateTimeWrapper>
                 <S.DeleteIconWrapper>
-                  {index > 0 && (
+                  {index === 0 ? (
+                    <FaCircleInfo />
+                  ) : (
                     <FaRegTrashCan
                       onClick={() => handleDeleteSchedule(index)}
                     />

--- a/src/pages/DashboardPage/DashboardInfoPage.jsx
+++ b/src/pages/DashboardPage/DashboardInfoPage.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import * as S from './DashboardInfoPage.style';
 import { FaAngleRight } from 'react-icons/fa6';
 import { Sidebar } from '../../components/Navigator';
@@ -15,6 +15,46 @@ export default function DashboardInfoPage() {
     'IT 실무자와 함께하는 제1회 빅데이터 활용 해커톤',
   );
   const [eventDescription, setEventDescription] = useState('행사설명 여기');
+  const [isChanged, setIsChanged] = useState(false);
+
+  const initialState = useRef({
+    active,
+    selectedOption,
+    startDate,
+    endDate,
+    eventTitle,
+    eventDescription,
+  });
+
+  useEffect(() => {
+    const hasChanged =
+      active !== initialState.current.active ||
+      selectedOption !== initialState.current.selectedOption ||
+      startDate.getTime() !== initialState.current.startDate.getTime() ||
+      endDate.getTime() !== initialState.current.endDate.getTime() ||
+      eventTitle !== initialState.current.eventTitle ||
+      eventDescription !== initialState.current.eventDescription;
+
+    setIsChanged(hasChanged);
+  }, [
+    active,
+    selectedOption,
+    startDate,
+    endDate,
+    eventTitle,
+    eventDescription,
+  ]);
+
+  useEffect(() => {
+    initialState.current = {
+      active,
+      selectedOption,
+      startDate,
+      endDate,
+      eventTitle,
+      eventDescription,
+    };
+  }, []);
 
   return (
     <PageLayout sideBar={<Sidebar />}>
@@ -22,7 +62,7 @@ export default function DashboardInfoPage() {
         <S.TopContainer>
           <S.Title>행사 기본 정보</S.Title>
           <S.ButtonContainer>
-            <BlueButton90>저장하기</BlueButton90>
+            <BlueButton90 disabled={!isChanged}>저장하기</BlueButton90>
           </S.ButtonContainer>
         </S.TopContainer>
 

--- a/src/pages/DashboardPage/DashboardInfoPage.jsx
+++ b/src/pages/DashboardPage/DashboardInfoPage.jsx
@@ -15,6 +15,7 @@ export default function DashboardInfoPage() {
   const [selectedOption, setSelectedOption] = useState('option1');
   const [eventTitle, setEventTitle] = useState('');
   const [eventDescription, setEventDescription] = useState('');
+  const [eventImage, setEventImage] = useState('');
   const [eventSchedules, setEventSchedules] = useState([
     {
       eventDate: new Date(),
@@ -30,6 +31,7 @@ export default function DashboardInfoPage() {
     selectedOption,
     eventTitle,
     eventDescription,
+    eventImage,
     eventSchedules,
   });
 
@@ -45,6 +47,7 @@ export default function DashboardInfoPage() {
         setSelectedOption(eventData.selectedOption || 'option1');
         setEventTitle(eventData.eventTitle);
         setEventDescription(eventData.eventDetail);
+        setEventImage(eventData.eventImage || '');
         setEventSchedules(
           eventData.eventSchedules.map((schedule) => ({
             eventDate: new Date(schedule.eventDate),
@@ -62,6 +65,7 @@ export default function DashboardInfoPage() {
           selectedOption: eventData.selectedOption || 'option1',
           eventTitle: eventData.eventTitle,
           eventDescription: eventData.eventDetail,
+          setImage: eventData.eventImage || '',
           eventSchedules: eventData.eventSchedules.map((schedule) => ({
             eventDate: new Date(schedule.eventDate),
             eventStartTime: new Date(
@@ -86,6 +90,7 @@ export default function DashboardInfoPage() {
       selectedOption !== initialState.current.selectedOption ||
       eventTitle !== initialState.current.eventTitle ||
       eventDescription !== initialState.current.eventDescription ||
+      eventImage !== initialState.current.eventImage ||
       eventSchedules.some(
         (schedule, index) =>
           schedule.eventDate.getTime() !==
@@ -99,7 +104,14 @@ export default function DashboardInfoPage() {
       );
 
     setIsChanged(hasChanged);
-  }, [active, selectedOption, eventTitle, eventDescription, eventSchedules]);
+  }, [
+    active,
+    selectedOption,
+    eventTitle,
+    eventDescription,
+    eventImage,
+    eventSchedules,
+  ]);
 
   const handleScheduleChange = (index, key, value) => {
     const newSchedules = [...eventSchedules];
@@ -112,7 +124,7 @@ export default function DashboardInfoPage() {
       EVENT_ID,
       eventTitle,
       eventDetail: eventDescription,
-      eventImage: '',
+      eventImage,
       eventSchedules: eventSchedules.map((schedule) => ({
         eventDate: schedule.eventDate.toISOString().split('T')[0],
         eventStartTime: schedule.eventStartTime.toISOString().split('T')[1],
@@ -275,6 +287,9 @@ export default function DashboardInfoPage() {
               <S.ContentDesc>
                 사진은 PNG, JPG, JPEG 파일만 가능 합니다.
               </S.ContentDesc>
+              {eventImage && (
+                <S.ImagePreview src={eventImage} alt="Event Cover" />
+              )}
               <UploadBox />
             </S.ContentDescWrapper>
           </S.Content>

--- a/src/pages/DashboardPage/DashboardInfoPage.jsx
+++ b/src/pages/DashboardPage/DashboardInfoPage.jsx
@@ -4,6 +4,7 @@ import { FaAngleRight } from 'react-icons/fa6';
 import { Sidebar } from '../../components/Navigator';
 import { BlueButton90 } from '../../components/Button';
 import PageLayout from '../../Layout/PageLayout';
+import UploadBox from '../../pages/RegisterPage/RegisterComponents/DragnDrop';
 
 export default function DashboardInfoPage() {
   const [active, setActive] = useState('online');
@@ -81,17 +82,6 @@ export default function DashboardInfoPage() {
             </S.DateTimeContainer>
           </S.Content>
           <S.Content>
-            <S.ContentTitle>행사 담당자 이메일</S.ContentTitle>
-            <S.ContentInput
-              type="text"
-              placeholder="checkmate@sookmyung.ac.kr"
-            />
-          </S.Content>
-          <S.Content>
-            <S.ContentTitle>행사 담당자 연락처</S.ContentTitle>
-            <S.ContentInput type="text" placeholder="010-1234-5678" />
-          </S.Content>
-          <S.Content>
             <S.ContentTitle>온라인/오프라인 여부</S.ContentTitle>
             <S.ToggleContainer>
               <S.ToggleBtn
@@ -151,9 +141,12 @@ export default function DashboardInfoPage() {
 
           <S.Content>
             <S.ContentTitle>행사 커버 이미지</S.ContentTitle>
-            <S.ContentDesc>
-              사진은 PNG, JPG, JPEG 파일만 가능 합니다.
-            </S.ContentDesc>
+            <S.ContentDescWrapper>
+              <S.ContentDesc>
+                사진은 PNG, JPG, JPEG 파일만 가능 합니다.
+              </S.ContentDesc>
+              <UploadBox />
+            </S.ContentDescWrapper>
           </S.Content>
         </S.ContentContainer>
       </S.DashboardInfo>

--- a/src/pages/DashboardPage/DashboardInfoPage.jsx
+++ b/src/pages/DashboardPage/DashboardInfoPage.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import * as S from './DashboardInfoPage.style';
-import { FaAngleRight } from 'react-icons/fa6';
+import { FaAngleRight, FaRegTrashCan } from 'react-icons/fa6';
 import { Sidebar } from '../../components/Navigator';
 import { BlueButton90 } from '../../components/Button';
 import { USER_ID } from '../../constants';
@@ -65,7 +65,7 @@ export default function DashboardInfoPage() {
           selectedOption: eventData.selectedOption || 'option1',
           eventTitle: eventData.eventTitle,
           eventDescription: eventData.eventDetail,
-          setImage: eventData.eventImage || '',
+          eventImage: eventData.eventImage || '',
           eventSchedules: eventData.eventSchedules.map((schedule) => ({
             eventDate: new Date(schedule.eventDate),
             eventStartTime: new Date(
@@ -121,7 +121,7 @@ export default function DashboardInfoPage() {
 
   const handleSave = async () => {
     const eventData = {
-      EVENT_ID,
+      eventId: EVENT_ID,
       eventTitle,
       eventDetail: eventDescription,
       eventImage,
@@ -131,6 +131,8 @@ export default function DashboardInfoPage() {
         eventEndTime: schedule.eventEndTime.toISOString().split('T')[1],
         attendanceListResponseDtos: [],
       })),
+      alaramRequest: true,
+      alarmResponse: true,
     };
 
     try {
@@ -142,6 +144,15 @@ export default function DashboardInfoPage() {
       setIsChanged(false);
     } catch (error) {
       alert('행사 정보를 저장하는 데 실패했습니다. 다시 시도해 주세요.');
+    }
+  };
+
+  const handleImageUpload = (event) => {
+    const file = event.target.files[0];
+    if (file) {
+      const filePath = URL.createObjectURL(file);
+      setEventImage(filePath);
+      setIsChanged(true);
     }
   };
 
@@ -172,51 +183,59 @@ export default function DashboardInfoPage() {
             <S.ContentTitle>행사 기간</S.ContentTitle>
             {eventSchedules.map((schedule, index) => (
               <S.DateTimeContainer key={index}>
-                <S.DateTimeInput
-                  selected={schedule.eventDate}
-                  onChange={(date) =>
-                    handleScheduleChange(index, 'eventDate', date)
-                  }
-                  dateFormat="MM월 dd일"
-                  showYearDropdown={false}
-                  showMonthDropdown={true}
-                  dropdownMode="select"
-                />
-                <S.DateTimeInput
-                  selected={schedule.eventStartTime}
-                  onChange={(date) =>
-                    handleScheduleChange(index, 'eventStartTime', date)
-                  }
-                  showTimeSelect
-                  showTimeSelectOnly
-                  timeIntervals={30}
-                  timeCaption="Time"
-                  dateFormat="h:mm aa"
-                />
-                <FaAngleRight />
-                <S.DateTimeInput
-                  selected={schedule.eventEndTime}
-                  onChange={(date) =>
-                    handleScheduleChange(index, 'eventEndTime', date)
-                  }
-                  dateFormat="MM월 dd일"
-                  showYearDropdown={false}
-                  showMonthDropdown={true}
-                  dropdownMode="select"
-                />
-                <S.DateTimeInput
-                  selected={schedule.eventEndTime}
-                  onChange={(date) =>
-                    handleScheduleChange(index, 'eventEndTime', date)
-                  }
-                  showTimeSelect
-                  showTimeSelectOnly
-                  timeIntervals={30}
-                  timeCaption="Time"
-                  dateFormat="h:mm aa"
-                />
+                <S.DateTimeWrapper>
+                  <S.DateTimeInput
+                    selected={schedule.eventDate}
+                    onChange={(date) =>
+                      handleScheduleChange(index, 'eventDate', date)
+                    }
+                    dateFormat="MM월 dd일"
+                    showYearDropdown={false}
+                    showMonthDropdown={true}
+                    dropdownMode="select"
+                  />
+                  <S.DateTimeInput
+                    selected={schedule.eventStartTime}
+                    onChange={(date) =>
+                      handleScheduleChange(index, 'eventStartTime', date)
+                    }
+                    showTimeSelect
+                    showTimeSelectOnly
+                    timeIntervals={30}
+                    timeCaption="Time"
+                    dateFormat="h:mm aa"
+                  />
+                  <FaAngleRight />
+                  <S.DateTimeInput
+                    selected={schedule.eventEndTime}
+                    onChange={(date) =>
+                      handleScheduleChange(index, 'eventEndTime', date)
+                    }
+                    dateFormat="MM월 dd일"
+                    showYearDropdown={false}
+                    showMonthDropdown={true}
+                    dropdownMode="select"
+                  />
+                  <S.DateTimeInput
+                    selected={schedule.eventEndTime}
+                    onChange={(date) =>
+                      handleScheduleChange(index, 'eventEndTime', date)
+                    }
+                    showTimeSelect
+                    showTimeSelectOnly
+                    timeIntervals={30}
+                    timeCaption="Time"
+                    dateFormat="h:mm aa"
+                  />
+                </S.DateTimeWrapper>
+                <S.DeleteIconWrapper>
+                  <FaRegTrashCan />
+                </S.DeleteIconWrapper>
               </S.DateTimeContainer>
             ))}
+            <S.AddTimeWrapper>
+              <S.AddTimeBtn>헹사 일정 추가하기</S.AddTimeBtn>
+            </S.AddTimeWrapper>
           </S.Content>
 
           <S.Content>
@@ -287,10 +306,10 @@ export default function DashboardInfoPage() {
               <S.ContentDesc>
                 사진은 PNG, JPG, JPEG 파일만 가능 합니다.
               </S.ContentDesc>
-              {eventImage && (
-                <S.ImagePreview src={eventImage} alt="Event Cover" />
-              )}
-              <UploadBox />
+              <UploadBox
+                imageUrl={eventImage}
+                onImageUpload={handleImageUpload}
+              />
             </S.ContentDescWrapper>
           </S.Content>
         </S.ContentContainer>

--- a/src/pages/DashboardPage/DashboardInfoPage.jsx
+++ b/src/pages/DashboardPage/DashboardInfoPage.jsx
@@ -119,6 +119,24 @@ export default function DashboardInfoPage() {
     setEventSchedules(newSchedules);
   };
 
+  // 행사 일정 추가하기 버튼
+  const handleAddSchedule = () => {
+    const newSchedule = {
+      eventDate: new Date(),
+      eventStartTime: new Date(),
+      eventEndTime: new Date(),
+    };
+    setEventSchedules([...eventSchedules, newSchedule]);
+    setIsChanged(true);
+  };
+
+  // 행사 일정 삭제하기 버튼
+  const handleDeleteSchedule = (index) => {
+    const newSchedules = eventSchedules.filter((_, i) => i !== index);
+    setEventSchedules(newSchedules);
+    setIsChanged(true);
+  };
+
   const handleSave = async () => {
     const eventData = {
       eventId: EVENT_ID,
@@ -228,13 +246,17 @@ export default function DashboardInfoPage() {
                     dateFormat="h:mm aa"
                   />
                 </S.DateTimeWrapper>
-                <S.DeleteIconWrapper>
+                <S.DeleteIconWrapper
+                  onClick={() => handleDeleteSchedule(index)}
+                >
                   <FaRegTrashCan />
                 </S.DeleteIconWrapper>
               </S.DateTimeContainer>
             ))}
             <S.AddTimeWrapper>
-              <S.AddTimeBtn>헹사 일정 추가하기</S.AddTimeBtn>
+              <S.AddTimeBtn onClick={handleAddSchedule}>
+                행사 일정 추가하기
+              </S.AddTimeBtn>
             </S.AddTimeWrapper>
           </S.Content>
 

--- a/src/pages/DashboardPage/DashboardInfoPage.jsx
+++ b/src/pages/DashboardPage/DashboardInfoPage.jsx
@@ -91,16 +91,17 @@ export default function DashboardInfoPage() {
       eventTitle !== initialState.current.eventTitle ||
       eventDescription !== initialState.current.eventDescription ||
       eventImage !== initialState.current.eventImage ||
+      eventSchedules.length !== initialState.current.eventSchedules.length ||
       eventSchedules.some(
         (schedule, index) =>
           schedule.eventDate.getTime() !==
-            initialState.current.eventSchedules[index].eventDate.getTime() ||
+            initialState.current.eventSchedules[index]?.eventDate.getTime() ||
           schedule.eventStartTime.getTime() !==
             initialState.current.eventSchedules[
               index
-            ].eventStartTime.getTime() ||
+            ]?.eventStartTime.getTime() ||
           schedule.eventEndTime.getTime() !==
-            initialState.current.eventSchedules[index].eventEndTime.getTime(),
+            initialState.current.eventSchedules[index]?.eventEndTime.getTime(),
       );
 
     setIsChanged(hasChanged);
@@ -117,14 +118,16 @@ export default function DashboardInfoPage() {
     const newSchedules = [...eventSchedules];
     newSchedules[index][key] = value;
     setEventSchedules(newSchedules);
+    setIsChanged(true);
   };
 
   // 행사 일정 추가하기 버튼
   const handleAddSchedule = () => {
+    const lastSchedule = eventSchedules[eventSchedules.length - 1];
     const newSchedule = {
-      eventDate: new Date(),
-      eventStartTime: new Date(),
-      eventEndTime: new Date(),
+      eventDate: new Date(lastSchedule.eventDate),
+      eventStartTime: new Date(lastSchedule.eventStartTime),
+      eventEndTime: new Date(lastSchedule.eventEndTime),
     };
     setEventSchedules([...eventSchedules, newSchedule]);
     setIsChanged(true);
@@ -132,9 +135,11 @@ export default function DashboardInfoPage() {
 
   // 행사 일정 삭제하기 버튼
   const handleDeleteSchedule = (index) => {
-    const newSchedules = eventSchedules.filter((_, i) => i !== index);
-    setEventSchedules(newSchedules);
-    setIsChanged(true);
+    if (eventSchedules.length > 1) {
+      const newSchedules = eventSchedules.filter((_, i) => i !== index);
+      setEventSchedules(newSchedules);
+      setIsChanged(true);
+    }
   };
 
   const handleSave = async () => {
@@ -246,10 +251,12 @@ export default function DashboardInfoPage() {
                     dateFormat="h:mm aa"
                   />
                 </S.DateTimeWrapper>
-                <S.DeleteIconWrapper
-                  onClick={() => handleDeleteSchedule(index)}
-                >
-                  <FaRegTrashCan />
+                <S.DeleteIconWrapper>
+                  {index > 0 && (
+                    <FaRegTrashCan
+                      onClick={() => handleDeleteSchedule(index)}
+                    />
+                  )}
                 </S.DeleteIconWrapper>
               </S.DateTimeContainer>
             ))}

--- a/src/pages/DashboardPage/DashboardInfoPage.jsx
+++ b/src/pages/DashboardPage/DashboardInfoPage.jsx
@@ -251,15 +251,19 @@ export default function DashboardInfoPage() {
                     dateFormat="h:mm aa"
                   />
                 </S.DateTimeWrapper>
-                <S.DeleteIconWrapper>
+                <S.InfoDeleteIconWrapper>
                   {index === 0 ? (
-                    <FaCircleInfo />
+                    <S.InfoIconWrapper>
+                      <FaCircleInfo />
+                    </S.InfoIconWrapper>
                   ) : (
-                    <FaRegTrashCan
+                    <S.DeleteIconWrapper
                       onClick={() => handleDeleteSchedule(index)}
-                    />
+                    >
+                      <FaRegTrashCan />
+                    </S.DeleteIconWrapper>
                   )}
-                </S.DeleteIconWrapper>
+                </S.InfoDeleteIconWrapper>
               </S.DateTimeContainer>
             ))}
             <S.AddTimeWrapper>

--- a/src/pages/DashboardPage/DashboardInfoPage.jsx
+++ b/src/pages/DashboardPage/DashboardInfoPage.jsx
@@ -11,6 +11,10 @@ export default function DashboardInfoPage() {
   const [selectedOption, setSelectedOption] = useState('option1');
   const [startDate, setStartDate] = useState(new Date());
   const [endDate, setEndDate] = useState(new Date());
+  const [eventTitle, setEventTitle] = useState(
+    'IT 실무자와 함께하는 제1회 빅데이터 활용 해커톤',
+  );
+  const [eventDescription, setEventDescription] = useState('행사설명 여기');
 
   return (
     <PageLayout sideBar={<Sidebar />}>
@@ -28,9 +32,11 @@ export default function DashboardInfoPage() {
             <S.ContentTitle>행사 제목</S.ContentTitle>
             <S.ContentInput
               type="text"
-              placeholder="IT 실무자와 함께하는 제1회 빅데이터 활용 해커톤"
+              value={eventTitle}
+              onChange={(e) => setEventTitle(e.target.value)}
             />
           </S.Content>
+
           <S.Content>
             <S.ContentTitle>행사 기간</S.ContentTitle>
             <S.DateTimeContainer>
@@ -81,6 +87,7 @@ export default function DashboardInfoPage() {
               />
             </S.DateTimeContainer>
           </S.Content>
+
           <S.Content>
             <S.ContentTitle>온라인/오프라인 여부</S.ContentTitle>
             <S.ToggleContainer>
@@ -98,6 +105,7 @@ export default function DashboardInfoPage() {
               </S.ToggleBtn>
             </S.ToggleContainer>
           </S.Content>
+
           <S.Content>
             <S.ContentTitle>행사 진행 대상</S.ContentTitle>
             <S.OptionContainer>
@@ -136,7 +144,10 @@ export default function DashboardInfoPage() {
 
           <S.Content>
             <S.ContentTitle>행사 설명</S.ContentTitle>
-            <S.Textarea />
+            <S.Textarea
+              value={eventDescription}
+              onChange={(e) => setEventDescription(e.target.value)}
+            />
           </S.Content>
 
           <S.Content>

--- a/src/pages/DashboardPage/DashboardInfoPage.style.jsx
+++ b/src/pages/DashboardPage/DashboardInfoPage.style.jsx
@@ -162,6 +162,7 @@ export const DateTimeContainer = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
+  padding-bottom: 6px;
 `;
 
 export const DateTimeInput = styled(DatePicker)`
@@ -169,7 +170,7 @@ export const DateTimeInput = styled(DatePicker)`
   border-radius: 8px;
   padding: 14px 10px;
   width: 90px;
-  height: 19px;
+  height: 14px;
   font-size: 16px;
   text-align: center;
 `;

--- a/src/pages/DashboardPage/DashboardInfoPage.style.jsx
+++ b/src/pages/DashboardPage/DashboardInfoPage.style.jsx
@@ -210,6 +210,12 @@ export const Textarea = styled.textarea`
   font-size: 16px;
 `;
 
+export const ContentDescWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+`;
+
 export const ContentDesc = styled.p`
   font-size: 14px;
   color: #666;

--- a/src/pages/DashboardPage/DashboardInfoPage.style.jsx
+++ b/src/pages/DashboardPage/DashboardInfoPage.style.jsx
@@ -191,8 +191,59 @@ export const Arrow = styled.div`
   height: 100%;
 `;
 
+export const InfoDeleteIconWrapper = styled.div`
+  display: flex;
+  position: relative;
+  justify-content: center;
+  align-items: center;
+  transition:
+    background-color 0.3s ease-in-out,
+    color 0.3s ease-in-out,
+    box-shadow 0.3s ease-in-out;
+`;
+
+export const InfoIconWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+  padding: 10px;
+
+  &:hover::after {
+    content: '최소 1개 이상의 일정을 등록해주세요.';
+    position: absolute;
+    top: 80%;
+    right: 0;
+    margin-top: 5px;
+    padding: 5px;
+    background-color: #333;
+    color: #fff;
+    border-radius: 4px;
+    white-space: nowrap;
+    font-size: 12px;
+    z-index: 1;
+    transition: opacity 0.2s ease-in-out;
+  }
+
+  &:hover::before {
+    content: '';
+    position: absolute;
+    top: 66%;
+    right: 50%;
+    transform: translateX(50%);
+    border-width: 6px;
+    border-style: solid;
+    border-color: transparent transparent #333 transparent;
+    z-index: 1;
+    transition: opacity 0.2s ease-in-out;
+  }
+`;
+
 export const DeleteIconWrapper = styled.button`
   display: flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
   justify-content: center;
   align-items: center;
   padding: 10px;

--- a/src/pages/DashboardPage/DashboardInfoPage.style.jsx
+++ b/src/pages/DashboardPage/DashboardInfoPage.style.jsx
@@ -160,26 +160,53 @@ export const OptionDescription = styled.span`
 // 행사 일정 선택
 export const DateTimeContainer = styled.div`
   display: flex;
-  justify-content: space-between;
   align-items: center;
   padding-bottom: 6px;
+`;
+
+export const DateTimeWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
 `;
 
 export const DateTimeInput = styled(DatePicker)`
   border: 1px solid #ccc;
   border-radius: 8px;
-  padding: 14px 10px;
+  padding: 10px 6px;
   width: 90px;
   height: 14px;
   font-size: 16px;
   text-align: center;
+
+  :focus {
+    border: 1px solid #ccc;
+    outline: none;
+  }
 `;
 
 export const Arrow = styled.div`
-  height: 100%;
   width: 100%;
+  height: 100%;
 `;
 
+export const DeleteIconWrapper = styled.button`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 10px;
+`;
+
+export const AddTimeWrapper = styled.div``;
+
+export const AddTimeBtn = styled.button`
+  color: #2253ff;
+  font-weight: 600;
+  padding: 6px;
+`;
+
+// 행사 내용
 export const Textarea = styled.textarea`
   border: 1px solid #ccc;
   border-radius: 8px;

--- a/src/pages/DashboardPage/DashboardInfoPage.style.jsx
+++ b/src/pages/DashboardPage/DashboardInfoPage.style.jsx
@@ -36,29 +36,6 @@ export const ButtonContainer = styled.div`
   gap: 10px;
 `;
 
-export const SaveBtn = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  background: #2253ff;
-  border-radius: 8px;
-  border: none;
-  padding: 9px 18px;
-  font-weight: 600;
-  font-size: 14px;
-  height: 40px;
-  color: #ffffff;
-  cursor: pointer;
-  transition:
-    background 0.3s ease,
-    box-shadow 0.3s ease,
-    transform 0.3s ease;
-
-  &:hover {
-    background: #4d74ff;
-  }
-`;
-
 // 행사 정보
 export const ContentContainer = styled.div`
   display: flex;

--- a/src/pages/DashboardPage/DashboardInfoPage.style.jsx
+++ b/src/pages/DashboardPage/DashboardInfoPage.style.jsx
@@ -198,3 +198,9 @@ export const ContentDesc = styled.p`
   font-size: 14px;
   color: #666;
 `;
+
+export const ImagePreview = styled.img`
+  max-width: 100%;
+  height: auto;
+  margin-top: 10px;
+`;

--- a/src/pages/DashboardPage/DashboardPage.style.jsx
+++ b/src/pages/DashboardPage/DashboardPage.style.jsx
@@ -36,9 +36,9 @@ export const ButtonContainer = styled.div`
 `;
 
 export const DeleteEventButton = styled(GrayButton90)`
-  box-sizing: border-box;
-  position: relative;
   display: inline-block;
+  position: relative;
+  box-sizing: border-box;
   transition:
     background-color 0.3s ease-in-out,
     color 0.3s ease-in-out,


### PR DESCRIPTION
## #️⃣ 관련 이슈

#113

## 📝 작업 내용

- 행사 기본 정보에 데이터 불러오는 API 연동
- 수정 사항 있을 경우에만 저장하기 버튼 활성화
- 행사 일정 추가 및 삭제 기능 구현
- 행사 기간 첫 줄에 정보 아이콘 추가 및 기능 구현
  <img src="https://github.com/user-attachments/assets/2dd47e5c-3f0e-4ed5-a4ba-d3c307cdbd7a" width="500"/>

## 📸 스크린샷

- 전체 화면
![image](https://github.com/user-attachments/assets/bbb9a455-981e-40b9-9ddb-73fd0499898a)

