### PR TITLE
#113 modify: 디테일 수정 및 담당자 연락처 유효성 검사

### DIFF
--- a/src/components/Navigator/Sidebar.jsx
+++ b/src/components/Navigator/Sidebar.jsx
@@ -3,7 +3,7 @@ import * as S from './Sidebar.style';
 import {
   FaTableList,
   FaCircleInfo,
-  FaEnvelope,
+  FaEnvelopeCircleCheck,
   FaUsers,
   FaChartPie,
 } from 'react-icons/fa6';
@@ -18,7 +18,7 @@ const menuItems = [
   },
   {
     to: '/event/dashboard/email',
-    icon: <FaEnvelope />,
+    icon: <FaEnvelopeCircleCheck />,
     text: '이메일 예약 발송',
   },
   { to: '/event/dashboard/attendee', icon: <FaUsers />, text: '참석자 관리' },

--- a/src/pages/DashboardPage/DashboardPage.jsx
+++ b/src/pages/DashboardPage/DashboardPage.jsx
@@ -15,6 +15,8 @@ export default function DashboardPage() {
   const [averageAttendance, setAverageAttendance] = useState(0);
   const [completedSessions, setCompletedSessions] = useState(0);
   const [eventStatus, setEventStatus] = useState('');
+  const [contacts, setContacts] = useState({ phone: '', email: '' });
+  const [isEditing, setIsEditing] = useState(false);
   const EVENT_ID = useRecoilValue(eventIDState);
   const navigate = useNavigate();
 
@@ -93,6 +95,23 @@ export default function DashboardPage() {
     fetchData();
   }, [EVENT_ID]);
 
+  // 담당자 연락처 추가 및 입력 필드 생성
+  const handleAddContact = () => {
+    if (isEditing) {
+      setIsEditing(false);
+    } else {
+      setIsEditing(true);
+    }
+  };
+
+  const handleInputChange = (e) => {
+    const { name, value } = e.target;
+    setContacts((prevContacts) => ({
+      ...prevContacts,
+      [name]: value,
+    }));
+  };
+
   // 행사 삭제
   const DeleteEvent = async () => {
     const isConfirmed = window.confirm('행사를 완전히 삭제하시겠습니까?');
@@ -137,7 +156,9 @@ export default function DashboardPage() {
           <S.ContentContainer>
             <S.OverviewContainer>
               <S.ContentBox>
-                <S.ContentTitle>행사 개요</S.ContentTitle>
+                <S.ContentTitleWrapper>
+                  <S.ContentTitle>행사 개요</S.ContentTitle>
+                </S.ContentTitleWrapper>
                 <S.ContentInfoWrapper>
                   <S.EventTypeWrapper>
                     <S.EventType>오프라인 행사</S.EventType>
@@ -154,10 +175,36 @@ export default function DashboardPage() {
               </S.ContentBox>
 
               <S.ContentBox>
-                <S.ContentTitle>담당자</S.ContentTitle>
+                <S.ContentTitleWrapper>
+                  <S.ContentTitle>담당자</S.ContentTitle>
+                  <S.AddContactButton onClick={handleAddContact}>
+                    {isEditing ? '저장' : '추가'}
+                  </S.AddContactButton>
+                </S.ContentTitleWrapper>
                 <S.ContentInfoWrapper>
-                  <S.ContentText>010-1234-5678</S.ContentText>
-                  <S.ContentText>checkmate@sookmyung.ac.kr</S.ContentText>
+                  {isEditing ? (
+                    <>
+                      <S.ContactInput
+                        type="text"
+                        name="phone"
+                        placeholder="핸드폰 번호"
+                        value={contacts.phone}
+                        onChange={handleInputChange}
+                      />
+                      <S.ContactInput
+                        type="email"
+                        name="email"
+                        placeholder="이메일"
+                        value={contacts.email}
+                        onChange={handleInputChange}
+                      />
+                    </>
+                  ) : (
+                    <>
+                      <S.ContentText>{contacts.phone}</S.ContentText>
+                      <S.ContentText>{contacts.email}</S.ContentText>
+                    </>
+                  )}
                 </S.ContentInfoWrapper>
               </S.ContentBox>
 
@@ -189,7 +236,9 @@ export default function DashboardPage() {
             {/* 진행 현황 */}
             <S.PosterImageContainer>
               <S.ContentBox>
-                <S.ContentTitle>행사 커버 이미지</S.ContentTitle>
+                <S.ContentTitleWrapper>
+                  <S.ContentTitle>행사 커버 이미지</S.ContentTitle>
+                </S.ContentTitleWrapper>
                 <S.ImageWrapper>
                   <img src={parsedEvents.image} alt="Event Cover" />
                 </S.ImageWrapper>

--- a/src/pages/DashboardPage/DashboardPage.jsx
+++ b/src/pages/DashboardPage/DashboardPage.jsx
@@ -1,5 +1,5 @@
 import * as S from './DashboardPage.style';
-import { FaRotate, FaUsers } from 'react-icons/fa6';
+import { FaEnvelope, FaPhone, FaRotate, FaUsers } from 'react-icons/fa6';
 import React, { useState, useEffect } from 'react';
 import PageLayout from '../../Layout/PageLayout';
 import { Sidebar } from '../../components/Navigator';
@@ -184,25 +184,47 @@ export default function DashboardPage() {
                 <S.ContentInfoWrapper>
                   {isEditing ? (
                     <>
-                      <S.ContactInput
-                        type="text"
-                        name="phone"
-                        placeholder="핸드폰 번호"
-                        value={contacts.phone}
-                        onChange={handleInputChange}
-                      />
-                      <S.ContactInput
-                        type="email"
-                        name="email"
-                        placeholder="이메일"
-                        value={contacts.email}
-                        onChange={handleInputChange}
-                      />
+                      <S.ContactIconInputWrapper>
+                        <FaPhone />
+                        <S.ContactInputWrapper>
+                          <S.ContactInput
+                            type="text"
+                            name="phone"
+                            placeholder="핸드폰 번호 ex) 010-1234-5678"
+                            value={contacts.phone}
+                            onChange={handleInputChange}
+                          />
+                          <S.ContactCheck>
+                            휴대폰 번호 형식이 올바르지 않습니다.
+                          </S.ContactCheck>
+                        </S.ContactInputWrapper>
+                      </S.ContactIconInputWrapper>
+                      <S.ContactIconInputWrapper>
+                        <FaEnvelope />
+                        <S.ContactInputWrapper>
+                          <S.ContactInput
+                            type="email"
+                            name="email"
+                            placeholder="이메일 ex) checkmate@sookmyung.ac.kr"
+                            value={contacts.email}
+                            onChange={handleInputChange}
+                          />
+                          <S.ContactCheck>
+                            이메일 형식이 올바르지 않습니다.
+                          </S.ContactCheck>
+                        </S.ContactInputWrapper>
+                      </S.ContactIconInputWrapper>
                     </>
                   ) : (
                     <>
-                      <S.ContentText>{contacts.phone}</S.ContentText>
-                      <S.ContentText>{contacts.email}</S.ContentText>
+                      <S.ContactIconTextWrapper>
+                        <FaPhone />
+                        <S.ContactText>{contacts.phone}</S.ContactText>
+                      </S.ContactIconTextWrapper>
+                      <S.ContactIconTextWrapper>
+                        <FaEnvelope />
+                        <S.ContactText>{contacts.email}</S.ContactText>
+                      </S.ContactIconTextWrapper>
                     </>
                   )}
                 </S.ContentInfoWrapper>

--- a/src/pages/DashboardPage/DashboardPage.jsx
+++ b/src/pages/DashboardPage/DashboardPage.jsx
@@ -11,7 +11,6 @@ import { axiosInstance } from '../../axios';
 import { useNavigate } from 'react-router-dom';
 
 export default function DashboardPage() {
-  const [copyMessage, setCopyMessage] = useState('');
   const [parsedEvents, setParsedEvents] = useState(null);
   const [averageAttendance, setAverageAttendance] = useState(0);
   const [completedSessions, setCompletedSessions] = useState(0);
@@ -93,21 +92,6 @@ export default function DashboardPage() {
     fetchData();
   }, [EVENT_ID]);
 
-  // 설문조사 링크 복사
-  const handleCopy = (text) => {
-    navigator.clipboard
-      .writeText(text)
-      .then(() => {
-        setCopyMessage('링크가 복사되었습니다!');
-        setTimeout(() => setCopyMessage(''), 3000);
-      })
-      .catch((err) => {
-        setCopyMessage('복사에 실패했습니다. 다시 시도해주세요.');
-        setTimeout(() => setCopyMessage(''), 3000);
-        console.error('복사 실패:', err);
-      });
-  };
-
   // 행사 삭제
   const DeleteEvent = async () => {
     const isConfirmed = window.confirm('행사를 완전히 삭제하시겠습니까?');
@@ -133,7 +117,6 @@ export default function DashboardPage() {
     <PageLayout sideBar={<Sidebar />}>
       {parsedEvents && (
         <S.DashboardPage>
-          {copyMessage && <S.CopyMessage>{copyMessage}</S.CopyMessage>}
           <S.TopContainer>
             <S.EventTitleWrapper>
               <S.EventTitle>{parsedEvents.title}</S.EventTitle>
@@ -152,58 +135,35 @@ export default function DashboardPage() {
           {/* 행사 정보 */}
           <S.ContentContainer>
             <S.OverviewContainer>
-              <S.OverviewWrapper>
-                <S.ContentBox>
-                  <S.ContentTitle>행사 개요</S.ContentTitle>
-                  <S.ContentInfoWrapper>
-                    <S.EventTypeWrapper>
-                      <S.EventType>오프라인 행사</S.EventType>
-                      <S.EventVenue>캠퍼스 내부</S.EventVenue>
-                    </S.EventTypeWrapper>
-                    <S.EventDateWrapper>
-                      {parsedEvents.schedules.map((schedule, index) => (
-                        <S.EventDate key={index}>
-                          {`• ${schedule.date} (${schedule.startTime} - ${schedule.endTime})`}
-                        </S.EventDate>
-                      ))}
-                    </S.EventDateWrapper>
-                  </S.ContentInfoWrapper>
-                </S.ContentBox>
-                <S.ContentBox>
-                  <S.ContentTitle>담당자</S.ContentTitle>
-                  <S.ContentInfoWrapper>
-                    <S.ContentText>010-1234-5678</S.ContentText>
-                    <S.ContentText>checkmate@sookmyung.ac.kr</S.ContentText>
-                  </S.ContentInfoWrapper>
-                </S.ContentBox>
-                <S.ContentBox>
-                  <S.ContentTitle>설문조사 링크</S.ContentTitle>
-                  <S.ContentTextWrapper>
-                    <S.ContentText>naver.com</S.ContentText>
-                    <S.CopyBtn onClick={() => handleCopy('naver.com')}>
-                      복사하기
-                    </S.CopyBtn>
-                  </S.ContentTextWrapper>
-                </S.ContentBox>
-              </S.OverviewWrapper>
+              <S.ContentBox>
+                <S.ContentTitle>행사 개요</S.ContentTitle>
+                <S.ContentInfoWrapper>
+                  <S.EventTypeWrapper>
+                    <S.EventType>오프라인 행사</S.EventType>
+                    <S.EventVenue>캠퍼스 내부</S.EventVenue>
+                  </S.EventTypeWrapper>
+                  <S.EventDateWrapper>
+                    {parsedEvents.schedules.map((schedule, index) => (
+                      <S.EventDate key={index}>
+                        {`• ${schedule.date} (${schedule.startTime} - ${schedule.endTime})`}
+                      </S.EventDate>
+                    ))}
+                  </S.EventDateWrapper>
+                </S.ContentInfoWrapper>
+              </S.ContentBox>
 
               <S.ContentBox>
-                <S.ContentTitle>QR 코드</S.ContentTitle>
-                <S.QrCode>
-                  <img
-                    src="https://www.google.com/url?sa=i&url=http%3A%2F%2Ft3.gstatic.com%2Flicensed-image%3Fq%3Dtbn%3AANd9GcSh-wrQu254qFaRcoYktJ5QmUhmuUedlbeMaQeaozAVD4lh4ICsGdBNubZ8UlMvWjKC&psig=AOvVaw3Zwwv5QaquDAu22BSpbs0n&ust=1720330468548000&source=images&cd=vfe&opi=89978449&ved=0CAkQjRxqFwoTCMijksXYkYcDFQAAAAAdAAAAABAE"
-                    alt=""
-                  />
-                </S.QrCode>
+                <S.ContentTitle>담당자</S.ContentTitle>
+                <S.ContentInfoWrapper>
+                  <S.ContentText>010-1234-5678</S.ContentText>
+                  <S.ContentText>checkmate@sookmyung.ac.kr</S.ContentText>
+                </S.ContentInfoWrapper>
               </S.ContentBox>
-            </S.OverviewContainer>
 
-            {/* 진행 현황 */}
-            <S.ProgressContainer>
               <S.ProgressBox>
-                <S.ProgressIcon>
+                <S.IconWrapper>
                   <FaUsers />
-                </S.ProgressIcon>
+                </S.IconWrapper>
                 <S.ProgressContentWrapper>
                   <S.ProgressTitle>평균 참석 인원</S.ProgressTitle>
                   <S.ProgressText>
@@ -213,9 +173,9 @@ export default function DashboardPage() {
               </S.ProgressBox>
 
               <S.ProgressBox>
-                <S.ProgressIcon>
+                <S.IconWrapper>
                   <FaRotate />
-                </S.ProgressIcon>
+                </S.IconWrapper>
                 <S.ProgressContentWrapper>
                   <S.ProgressTitle>진행 회차</S.ProgressTitle>
                   <S.ProgressText>
@@ -223,6 +183,19 @@ export default function DashboardPage() {
                   </S.ProgressText>
                 </S.ProgressContentWrapper>
               </S.ProgressBox>
+            </S.OverviewContainer>
+
+            {/* 진행 현황 */}
+            <S.ProgressContainer>
+              <S.ContentBox>
+                <S.ContentTitle>QR 코드</S.ContentTitle>
+                <S.QrCode>
+                  <img
+                    src="https://www.google.com/url?sa=i&url=http%3A%2F%2Ft3.gstatic.com%2Flicensed-image%3Fq%3Dtbn%3AANd9GcSh-wrQu254qFaRcoYktJ5QmUhmuUedlbeMaQeaozAVD4lh4ICsGdBNubZ8UlMvWjKC&psig=AOvVaw3Zwwv5QaquDAu22BSpbs0n&ust=1720330468548000&source=images&cd=vfe&opi=89978449&ved=0CAkQjRxqFwoTCMijksXYkYcDFQAAAAAdAAAAABAE"
+                    alt=""
+                  />
+                </S.QrCode>
+              </S.ContentBox>
             </S.ProgressContainer>
           </S.ContentContainer>
         </S.DashboardPage>

--- a/src/pages/DashboardPage/DashboardPage.jsx
+++ b/src/pages/DashboardPage/DashboardPage.jsx
@@ -187,14 +187,14 @@ export default function DashboardPage() {
             </S.OverviewContainer>
 
             {/* 진행 현황 */}
-            <S.ProgressContainer>
+            <S.PosterImageContainer>
               <S.ContentBox>
                 <S.ContentTitle>행사 커버 이미지</S.ContentTitle>
                 <S.ImageWrapper>
                   <img src={parsedEvents.image} alt="Event Cover" />
                 </S.ImageWrapper>
               </S.ContentBox>
-            </S.ProgressContainer>
+            </S.PosterImageContainer>
           </S.ContentContainer>
         </S.DashboardPage>
       )}

--- a/src/pages/DashboardPage/DashboardPage.jsx
+++ b/src/pages/DashboardPage/DashboardPage.jsx
@@ -61,6 +61,7 @@ export default function DashboardPage() {
           const parsedEvent = {
             title: eventData.eventTitle,
             detail: eventData.eventDetail,
+            image: eventData.eventImage,
             schedules,
             totalSessions: eventData.eventSchedules.length,
             totalParticipants,
@@ -188,13 +189,10 @@ export default function DashboardPage() {
             {/* 진행 현황 */}
             <S.ProgressContainer>
               <S.ContentBox>
-                <S.ContentTitle>QR 코드</S.ContentTitle>
-                <S.QrCode>
-                  <img
-                    src="https://www.google.com/url?sa=i&url=http%3A%2F%2Ft3.gstatic.com%2Flicensed-image%3Fq%3Dtbn%3AANd9GcSh-wrQu254qFaRcoYktJ5QmUhmuUedlbeMaQeaozAVD4lh4ICsGdBNubZ8UlMvWjKC&psig=AOvVaw3Zwwv5QaquDAu22BSpbs0n&ust=1720330468548000&source=images&cd=vfe&opi=89978449&ved=0CAkQjRxqFwoTCMijksXYkYcDFQAAAAAdAAAAABAE"
-                    alt=""
-                  />
-                </S.QrCode>
+                <S.ContentTitle>행사 커버 이미지</S.ContentTitle>
+                <S.ImageWrapper>
+                  <img src={parsedEvents.image} alt="Event Cover" />
+                </S.ImageWrapper>
               </S.ContentBox>
             </S.ProgressContainer>
           </S.ContentContainer>

--- a/src/pages/DashboardPage/DashboardPage.jsx
+++ b/src/pages/DashboardPage/DashboardPage.jsx
@@ -1,5 +1,5 @@
 import * as S from './DashboardPage.style';
-import { FaEnvelope, FaPhone, FaRotate, FaUsers } from 'react-icons/fa6';
+import { FaRotate, FaUsers } from 'react-icons/fa6';
 import React, { useState, useEffect } from 'react';
 import PageLayout from '../../Layout/PageLayout';
 import { Sidebar } from '../../components/Navigator';
@@ -185,7 +185,9 @@ export default function DashboardPage() {
                   {isEditing ? (
                     <>
                       <S.ContactIconInputWrapper>
-                        <FaPhone />
+                        <S.ContactIconWrapper>
+                          <S.StyledPhoneIcon />
+                        </S.ContactIconWrapper>
                         <S.ContactInputWrapper>
                           <S.ContactInput
                             type="text"
@@ -199,8 +201,11 @@ export default function DashboardPage() {
                           </S.ContactCheck>
                         </S.ContactInputWrapper>
                       </S.ContactIconInputWrapper>
+
                       <S.ContactIconInputWrapper>
-                        <FaEnvelope />
+                        <S.ContactIconWrapper>
+                          <S.StyledEnvelopeIcon />
+                        </S.ContactIconWrapper>
                         <S.ContactInputWrapper>
                           <S.ContactInput
                             type="email"
@@ -218,11 +223,15 @@ export default function DashboardPage() {
                   ) : (
                     <>
                       <S.ContactIconTextWrapper>
-                        <FaPhone />
+                        <S.ContactIconWrapper>
+                          <S.StyledPhoneIcon />
+                        </S.ContactIconWrapper>
                         <S.ContactText>{contacts.phone}</S.ContactText>
                       </S.ContactIconTextWrapper>
                       <S.ContactIconTextWrapper>
-                        <FaEnvelope />
+                        <S.ContactIconWrapper>
+                          <S.StyledEnvelopeIcon />
+                        </S.ContactIconWrapper>
                         <S.ContactText>{contacts.email}</S.ContactText>
                       </S.ContactIconTextWrapper>
                     </>

--- a/src/pages/DashboardPage/DashboardPage.jsx
+++ b/src/pages/DashboardPage/DashboardPage.jsx
@@ -17,6 +17,9 @@ export default function DashboardPage() {
   const [eventStatus, setEventStatus] = useState('');
   const [contacts, setContacts] = useState({ phone: '', email: '' });
   const [isEditing, setIsEditing] = useState(false);
+  const [phoneError, setPhoneError] = useState(false);
+  const [emailError, setEmailError] = useState(false);
+
   const EVENT_ID = useRecoilValue(eventIDState);
   const navigate = useNavigate();
 
@@ -95,23 +98,6 @@ export default function DashboardPage() {
     fetchData();
   }, [EVENT_ID]);
 
-  // 담당자 연락처 추가 및 입력 필드 생성
-  const handleAddContact = () => {
-    if (isEditing) {
-      setIsEditing(false);
-    } else {
-      setIsEditing(true);
-    }
-  };
-
-  const handleInputChange = (e) => {
-    const { name, value } = e.target;
-    setContacts((prevContacts) => ({
-      ...prevContacts,
-      [name]: value,
-    }));
-  };
-
   // 행사 삭제
   const DeleteEvent = async () => {
     const isConfirmed = window.confirm('행사를 완전히 삭제하시겠습니까?');
@@ -131,6 +117,46 @@ export default function DashboardPage() {
       alert('행사 삭제에 실패했습니다. 다시 시도해 주세요.');
       console.log(error);
     }
+  };
+
+  // 담당자 연락처 추가 및 입력 필드 생성
+  const handleAddContact = () => {
+    if (isEditing) {
+      const isPhoneValid = validatePhoneNumber(contacts.phone);
+      const isEmailValid = validateEmail(contacts.email);
+      setPhoneError(!isPhoneValid);
+      setEmailError(!isEmailValid);
+
+      if (isPhoneValid && isEmailValid) {
+        setIsEditing(false);
+      }
+    } else {
+      setIsEditing(true);
+    }
+  };
+
+  const handleInputChange = (e) => {
+    const { name, value } = e.target;
+    setContacts((prevContacts) => ({
+      ...prevContacts,
+      [name]: value,
+    }));
+
+    if (name === 'phone') {
+      setPhoneError(!validatePhoneNumber(value));
+    } else if (name === 'email') {
+      setEmailError(!validateEmail(value));
+    }
+  };
+
+  const validatePhoneNumber = (phone) => {
+    const phoneRegex = /^010-\d{4}-\d{4}$/;
+    return phoneRegex.test(phone);
+  };
+
+  const validateEmail = (email) => {
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    return emailRegex.test(email);
   };
 
   return (
@@ -196,9 +222,11 @@ export default function DashboardPage() {
                             value={contacts.phone}
                             onChange={handleInputChange}
                           />
-                          <S.ContactCheck>
-                            휴대폰 번호 형식이 올바르지 않습니다.
-                          </S.ContactCheck>
+                          {phoneError && (
+                            <S.ContactCheck>
+                              휴대폰 번호 형식이 올바르지 않습니다.
+                            </S.ContactCheck>
+                          )}
                         </S.ContactInputWrapper>
                       </S.ContactIconInputWrapper>
 
@@ -214,9 +242,11 @@ export default function DashboardPage() {
                             value={contacts.email}
                             onChange={handleInputChange}
                           />
-                          <S.ContactCheck>
-                            이메일 형식이 올바르지 않습니다.
-                          </S.ContactCheck>
+                          {emailError && (
+                            <S.ContactCheck>
+                              이메일 형식이 올바르지 않습니다.
+                            </S.ContactCheck>
+                          )}
                         </S.ContactInputWrapper>
                       </S.ContactIconInputWrapper>
                     </>

--- a/src/pages/DashboardPage/DashboardPage.style.jsx
+++ b/src/pages/DashboardPage/DashboardPage.style.jsx
@@ -95,6 +95,7 @@ export const EventTitleWrapper = styled.div`
 `;
 
 export const EventTitle = styled.h1`
+  display: flex;
   font-weight: bold;
   font-size: 24px;
   line-height: 29px;
@@ -116,6 +117,13 @@ export const Badge = styled.span`
       : props.status === '진행중'
         ? 'var(--blue-400, #0075ff)'
         : '#ffa726'};
+  border: 1px solid
+    ${(props) =>
+      props.status === '종료'
+        ? '#ff6b6b'
+        : props.status === '진행중'
+          ? 'var(--blue-400, #0075ff)'
+          : '#ffa726'};
 `;
 
 // 행사 정보
@@ -144,14 +152,38 @@ export const ContentBox = styled.div`
   border-radius: 10px;
 `;
 
-export const ContentTitle = styled.h3`
-  width: 100%;
+export const ContentTitleWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
   padding-bottom: 8px;
-  line-height: 19px;
   border-bottom: 1px solid var(--gray-200, #d9d9d9);
+`;
+
+export const ContentTitle = styled.h3`
+  line-height: 19px;
   color: var(--gray-400, #212121);
   font-weight: bold;
   font-size: 16px;
+`;
+
+export const AddContactButton = styled.button`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 12px;
+  padding: 4px 10px;
+  color: #2253ff;
+  font-weight: 600;
+  font-size: 12px;
+  border: 1px solid var(--blue-400, #2253ff);
+`;
+
+export const ContactInput = styled.input`
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  padding: 6px 10px;
+  font-size: 14px;
 `;
 
 export const ContentInfoWrapper = styled.div`

--- a/src/pages/DashboardPage/DashboardPage.style.jsx
+++ b/src/pages/DashboardPage/DashboardPage.style.jsx
@@ -2,6 +2,7 @@ import styled from 'styled-components';
 import { Link } from 'react-router-dom';
 import { GrayButton90 } from '../../components';
 import { BREAKPOINTS } from '../../styles';
+import { FaEnvelope, FaPhone } from 'react-icons/fa6';
 
 export const DashboardPage = styled.div`
   flex-grow: 1;
@@ -181,7 +182,6 @@ export const AddContactButton = styled.button`
 
 export const ContactIconInputWrapper = styled.div`
   display: flex;
-  align-items: center;
   gap: 8px;
 `;
 
@@ -207,15 +207,32 @@ export const ContactCheck = styled.p`
 
 export const ContactIconTextWrapper = styled.div`
   display: flex;
-  align-items: center;
   gap: 8px;
 `;
 
-export const ContactText = styled.div`
-  border: none;
-  line-height: 14px;
-  font-size: 14px;
+export const ContactIconWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  height: 100%;
+  padding-top: 7px;
+`;
+
+export const StyledPhoneIcon = styled(FaPhone)`
   color: var(--gray-300, #636363);
+`;
+
+export const StyledEnvelopeIcon = styled(FaEnvelope)`
+  color: var(--gray-300, #636363);
+`;
+
+export const ContactText = styled.div`
+  display: flex;
+  align-items: center;
+  border: none;
+  padding-top: 7px;
+  line-height: 14px;
+  color: var(--gray-300, #636363);
+  font-size: 14px;
 `;
 
 export const ContentInfoWrapper = styled.div`

--- a/src/pages/DashboardPage/DashboardPage.style.jsx
+++ b/src/pages/DashboardPage/DashboardPage.style.jsx
@@ -216,43 +216,13 @@ export const ImageWrapper = styled.div`
 
   img {
     display: block;
-    width: 100%;
+    width: 70%;
     object-fit: contain;
   }
 `;
 
-export const CopyBtn = styled.button`
-  margin-left: auto;
-  border-radius: 4px;
-  border: none;
-  background: var(--blue-400, #0075ff);
-  width: 60px;
-  height: 22px;
-  line-height: 20px;
-  color: #ffffff;
-  font-size: 11px;
-  cursor: pointer;
-
-  &:hover {
-    background: var(--blue-300, #2c8dff);
-  }
-`;
-
-export const CopyMessage = styled.div`
-  position: fixed;
-  top: 20px;
-  left: 50%;
-  transform: translateX(-50%);
-  background: var(--blue-400, #0075ff);
-  color: #ffffff;
-  padding: 10px 20px;
-  border-radius: 5px;
-  box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.1);
-  z-index: 1000;
-`;
-
 // 진행 현황
-export const ProgressContainer = styled.div`
+export const PosterImageContainer = styled.div`
   display: flex;
   gap: 10px;
   width: 100%;

--- a/src/pages/DashboardPage/DashboardPage.style.jsx
+++ b/src/pages/DashboardPage/DashboardPage.style.jsx
@@ -205,19 +205,18 @@ export const EventDate = styled.p`
   color: var(--gray-300, #636363);
 `;
 
-export const QrCode = styled.div`
+export const ImageWrapper = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  padding: 20px;
+  padding: 20px 0;
   width: 100%;
   height: 100%;
 
   img {
     display: block;
-    max-width: 100%;
-    max-height: 200px;
+    width: 100%;
     object-fit: contain;
   }
 `;

--- a/src/pages/DashboardPage/DashboardPage.style.jsx
+++ b/src/pages/DashboardPage/DashboardPage.style.jsx
@@ -179,11 +179,43 @@ export const AddContactButton = styled.button`
   border: 1px solid var(--blue-400, #2253ff);
 `;
 
+export const ContactIconInputWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`;
+
+export const ContactInputWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  gap: 4px;
+`;
+
 export const ContactInput = styled.input`
   border: 1px solid #ddd;
   border-radius: 6px;
   padding: 6px 10px;
   font-size: 14px;
+`;
+
+export const ContactCheck = styled.p`
+  padding: 0 6px;
+  font-size: 12px;
+  color: #ff6b6b;
+`;
+
+export const ContactIconTextWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`;
+
+export const ContactText = styled.div`
+  border: none;
+  line-height: 14px;
+  font-size: 14px;
+  color: var(--gray-300, #636363);
 `;
 
 export const ContentInfoWrapper = styled.div`

--- a/src/pages/DashboardPage/DashboardPage.style.jsx
+++ b/src/pages/DashboardPage/DashboardPage.style.jsx
@@ -121,21 +121,14 @@ export const Badge = styled.span`
 // 행사 정보
 export const ContentContainer = styled.div`
   display: flex;
-  flex-direction: column;
   gap: 10px;
-`;
-
-export const OverviewContainer = styled.div`
-  display: flex;
-  gap: 10px;
-  width: 100%;
 
   @media (max-width: ${BREAKPOINTS[1]}px) {
     flex-direction: column;
   }
 `;
 
-export const OverviewWrapper = styled.div`
+export const OverviewContainer = styled.div`
   display: flex;
   flex-direction: column;
   gap: 10px;
@@ -281,7 +274,7 @@ export const ProgressBox = styled.div`
   gap: 18px;
 `;
 
-export const ProgressIcon = styled.div`
+export const IconWrapper = styled.div`
   display: flex;
   justify-content: center;
   background: var(--blue-400, #0075ff);

--- a/src/pages/DashboardPage/DashboardPage.style.jsx
+++ b/src/pages/DashboardPage/DashboardPage.style.jsx
@@ -303,6 +303,7 @@ export const ProgressTitle = styled.h3`
 `;
 
 export const ProgressText = styled.p`
+  width: 100px;
   font-weight: bold;
   font-size: 20px;
   color: var(--gray-300, #636363);


### PR DESCRIPTION
## #️⃣ 관련 이슈

#113

## 📝 작업 내용

- 대시포드 페이지 재정렬
- QR코드 → `행사 커버 이미지`로 대체 및 API 연동
- 담당자 연락처 유효성 검사
  - 올바르지 않은 상태
  <img width="400" alt="image" src="https://github.com/user-attachments/assets/ef7f87e2-749d-429d-b8ca-bb64dd99204f">

  - 올바른 상태
  <img width="400" alt="image" src="https://github.com/user-attachments/assets/f141f8b2-99e4-43dc-93eb-fdb1b614f4d2">

  - 입력 완료 후  
  <img width="400" alt="image" src="https://github.com/user-attachments/assets/4ec48ab9-8f59-40d1-9152-398fd944bdd1">



## 📸 스크린샷
![image](https://github.com/user-attachments/assets/b452285b-498a-46e5-8520-d447b933920e)
