### PR TITLE
#113 fix: eventType 및 eventTarget 데이터 불러오는 API 연동

### DIFF
--- a/src/pages/DashboardPage/DashboardInfoPage.jsx
+++ b/src/pages/DashboardPage/DashboardInfoPage.jsx
@@ -12,7 +12,7 @@ import UploadBox from '../../pages/RegisterPage/RegisterComponents/DragnDrop';
 
 export default function DashboardInfoPage() {
   const [eventType, setEventType] = useState('OFFLINE');
-  const [selectedOption, setSelectedOption] = useState('option1');
+  const [eventTarget, setEventTarget] = useState('EXTERNAL');
   const [eventTitle, setEventTitle] = useState('');
   const [eventDescription, setEventDescription] = useState('');
   const [eventImage, setEventImage] = useState('');
@@ -28,7 +28,7 @@ export default function DashboardInfoPage() {
 
   const initialState = useRef({
     eventType,
-    selectedOption,
+    eventTarget,
     eventTitle,
     eventDescription,
     eventImage,
@@ -44,7 +44,7 @@ export default function DashboardInfoPage() {
         const eventData = response.data;
 
         setEventType(eventData.eventType ? 'ONLINE' : 'OFFLINE');
-        setSelectedOption(eventData.selectedOption || 'option1');
+        setEventTarget(eventData.eventTarget || 'EXTERNAL : INTERNAL');
         setEventTitle(eventData.eventTitle);
         setEventDescription(eventData.eventDetail);
         setEventImage(eventData.eventImage || '');
@@ -62,7 +62,7 @@ export default function DashboardInfoPage() {
 
         initialState.current = {
           eventType: eventData.eventType ? 'ONLINE' : 'OFFLINE',
-          selectedOption: eventData.selectedOption || 'option1',
+          eventTarget: eventData.eventTarget || 'EXTERNAL',
           eventTitle: eventData.eventTitle,
           eventDescription: eventData.eventDetail,
           eventImage: eventData.eventImage || '',
@@ -87,7 +87,7 @@ export default function DashboardInfoPage() {
   useEffect(() => {
     const hasChanged =
       eventType !== initialState.current.eventType ||
-      selectedOption !== initialState.current.selectedOption ||
+      eventTarget !== initialState.current.eventTarget ||
       eventTitle !== initialState.current.eventTitle ||
       eventDescription !== initialState.current.eventDescription ||
       eventImage !== initialState.current.eventImage ||
@@ -107,7 +107,7 @@ export default function DashboardInfoPage() {
     setIsChanged(hasChanged);
   }, [
     eventType,
-    selectedOption,
+    eventTarget,
     eventTitle,
     eventDescription,
     eventImage,
@@ -284,38 +284,38 @@ export default function DashboardInfoPage() {
 
           <S.Content>
             <S.ContentTitle>행사 진행 대상</S.ContentTitle>
-            <S.OptionContainer>
-              <S.Option onClick={() => setSelectedOption('option1')}>
-                <S.RadioButton
+            <S.EventTargetContainer>
+              <S.EventTarget onClick={() => setEventTarget('EXTERNAL')}>
+                <S.EventTargetRadioButton
                   type="radio"
                   name="platform"
-                  value="option1"
-                  checked={selectedOption === 'option1'}
+                  value="EXTERNAL"
+                  checked={eventTarget === 'EXTERNAL'}
                   readOnly
                 />
-                <S.TextContainer>
-                  <S.OptionTitle>숙명여자대학교 학생</S.OptionTitle>
-                  <S.OptionDescription>
+                <S.EventTargetWrapper>
+                  <S.EventTargetTitle>숙명여자대학교 학생</S.EventTargetTitle>
+                  <S.EventTargetDescription>
                     출석체크시, 학번을 입력받습니다.
-                  </S.OptionDescription>
-                </S.TextContainer>
-              </S.Option>
-              <S.Option onClick={() => setSelectedOption('option2')}>
-                <S.RadioButton
+                  </S.EventTargetDescription>
+                </S.EventTargetWrapper>
+              </S.EventTarget>
+              <S.EventTarget onClick={() => setEventTarget('INTERNAL')}>
+                <S.EventTargetRadioButton
                   type="radio"
                   name="platform"
-                  value="option2"
-                  checked={selectedOption === 'option2'}
+                  value="INTERNAL"
+                  checked={eventTarget === 'INTERNAL'}
                   readOnly
                 />
-                <S.TextContainer>
-                  <S.OptionTitle>외부인</S.OptionTitle>
-                  <S.OptionDescription>
+                <S.EventTargetWrapper>
+                  <S.EventTargetTitle>외부인</S.EventTargetTitle>
+                  <S.EventTargetDescription>
                     출석체크시, 휴대폰 번호를 입력받습니다.
-                  </S.OptionDescription>
-                </S.TextContainer>
-              </S.Option>
-            </S.OptionContainer>
+                  </S.EventTargetDescription>
+                </S.EventTargetWrapper>
+              </S.EventTarget>
+            </S.EventTargetContainer>
           </S.Content>
 
           <S.Content>

--- a/src/pages/DashboardPage/DashboardInfoPage.jsx
+++ b/src/pages/DashboardPage/DashboardInfoPage.jsx
@@ -229,16 +229,7 @@ export default function DashboardInfoPage() {
                     dateFormat="h:mm aa"
                   />
                   <FaAngleRight />
-                  <S.DateTimeInput
-                    selected={schedule.eventEndTime}
-                    onChange={(date) =>
-                      handleScheduleChange(index, 'eventEndTime', date)
-                    }
-                    dateFormat="MM월 dd일"
-                    showYearDropdown={false}
-                    showMonthDropdown={true}
-                    dropdownMode="select"
-                  />
+
                   <S.DateTimeInput
                     selected={schedule.eventEndTime}
                     onChange={(date) =>

--- a/src/pages/DashboardPage/DashboardInfoPage.jsx
+++ b/src/pages/DashboardPage/DashboardInfoPage.jsx
@@ -62,7 +62,7 @@ export default function DashboardInfoPage() {
 
         initialState.current = {
           eventType: eventData.eventType ? 'ONLINE' : 'OFFLINE',
-          eventTarget: eventData.eventTarget || 'EXTERNAL',
+          eventTarget: eventData.eventTarget || 'EXTERNAL : INTERNAL',
           eventTitle: eventData.eventTitle,
           eventDescription: eventData.eventDetail,
           eventImage: eventData.eventImage || '',
@@ -121,7 +121,7 @@ export default function DashboardInfoPage() {
     setIsChanged(true);
   };
 
-  // 행사 일정 추가하기 버튼
+  // 행사 기간 추가하기 버튼
   const handleAddSchedule = () => {
     const lastSchedule = eventSchedules[eventSchedules.length - 1];
     const newSchedule = {
@@ -133,7 +133,7 @@ export default function DashboardInfoPage() {
     setIsChanged(true);
   };
 
-  // 행사 일정 삭제하기 버튼
+  // 행사 기간 삭제하기 버튼
   const handleDeleteSchedule = (index) => {
     if (eventSchedules.length > 1) {
       const newSchedules = eventSchedules.filter((_, i) => i !== index);
@@ -142,6 +142,7 @@ export default function DashboardInfoPage() {
     }
   };
 
+  // 저장하기 버튼
   const handleSave = async () => {
     const eventData = {
       eventId: EVENT_ID,

--- a/src/pages/DashboardPage/DashboardInfoPage.jsx
+++ b/src/pages/DashboardPage/DashboardInfoPage.jsx
@@ -149,14 +149,14 @@ export default function DashboardInfoPage() {
       eventTitle,
       eventDetail: eventDescription,
       eventImage,
+      eventType: eventType === 'ONLINE' ? 'ONLINE' : 'OFFLINE',
+      eventTarget: eventTarget === 'EXTERNAL' ? 'EXTERNAL' : 'INTERNAL',
       eventSchedules: eventSchedules.map((schedule) => ({
         eventDate: schedule.eventDate.toISOString().split('T')[0],
         eventStartTime: schedule.eventStartTime.toISOString().split('T')[1],
         eventEndTime: schedule.eventEndTime.toISOString().split('T')[1],
         attendanceListResponseDtos: [],
       })),
-      alaramRequest: true,
-      alarmResponse: true,
     };
 
     try {
@@ -168,6 +168,7 @@ export default function DashboardInfoPage() {
       setIsChanged(false);
     } catch (error) {
       alert('행사 정보를 저장하는 데 실패했습니다. 다시 시도해 주세요.');
+      console.error('행사 정보 저장 실패: ', error);
     }
   };
 

--- a/src/pages/DashboardPage/DashboardInfoPage.jsx
+++ b/src/pages/DashboardPage/DashboardInfoPage.jsx
@@ -11,7 +11,7 @@ import PageLayout from '../../Layout/PageLayout';
 import UploadBox from '../../pages/RegisterPage/RegisterComponents/DragnDrop';
 
 export default function DashboardInfoPage() {
-  const [active, setActive] = useState('online');
+  const [eventType, setEventType] = useState('OFFLINE');
   const [selectedOption, setSelectedOption] = useState('option1');
   const [eventTitle, setEventTitle] = useState('');
   const [eventDescription, setEventDescription] = useState('');
@@ -27,7 +27,7 @@ export default function DashboardInfoPage() {
   const EVENT_ID = useRecoilValue(eventIDState);
 
   const initialState = useRef({
-    active,
+    eventType,
     selectedOption,
     eventTitle,
     eventDescription,
@@ -43,7 +43,7 @@ export default function DashboardInfoPage() {
         );
         const eventData = response.data;
 
-        setActive(eventData.active ? 'online' : 'offline');
+        setEventType(eventData.eventType ? 'ONLINE' : 'OFFLINE');
         setSelectedOption(eventData.selectedOption || 'option1');
         setEventTitle(eventData.eventTitle);
         setEventDescription(eventData.eventDetail);
@@ -61,7 +61,7 @@ export default function DashboardInfoPage() {
         );
 
         initialState.current = {
-          active: eventData.active ? 'online' : 'offline',
+          eventType: eventData.eventType ? 'ONLINE' : 'OFFLINE',
           selectedOption: eventData.selectedOption || 'option1',
           eventTitle: eventData.eventTitle,
           eventDescription: eventData.eventDetail,
@@ -86,7 +86,7 @@ export default function DashboardInfoPage() {
 
   useEffect(() => {
     const hasChanged =
-      active !== initialState.current.active ||
+      eventType !== initialState.current.eventType ||
       selectedOption !== initialState.current.selectedOption ||
       eventTitle !== initialState.current.eventTitle ||
       eventDescription !== initialState.current.eventDescription ||
@@ -106,7 +106,7 @@ export default function DashboardInfoPage() {
 
     setIsChanged(hasChanged);
   }, [
-    active,
+    eventType,
     selectedOption,
     eventTitle,
     eventDescription,
@@ -268,14 +268,14 @@ export default function DashboardInfoPage() {
             <S.ContentTitle>온라인/오프라인 여부</S.ContentTitle>
             <S.ToggleContainer>
               <S.ToggleBtn
-                active={active === 'online'}
-                onClick={() => setActive('online')}
+                active={eventType === 'ONLINE'}
+                onClick={() => setEventType('ONLINE')}
               >
                 온라인
               </S.ToggleBtn>
               <S.ToggleBtn
-                active={active === 'offline'}
-                onClick={() => setActive('offline')}
+                active={eventType === 'OFFLINE'}
+                onClick={() => setEventType('OFFLINE')}
               >
                 오프라인
               </S.ToggleBtn>

--- a/src/pages/DashboardPage/DashboardInfoPage.style.jsx
+++ b/src/pages/DashboardPage/DashboardInfoPage.style.jsx
@@ -100,13 +100,13 @@ export const ToggleBtn = styled.button`
 `;
 
 // 장소 옵션
-export const OptionContainer = styled.div`
+export const EventTargetContainer = styled.div`
   display: flex;
   flex-direction: column;
   gap: 4px;
 `;
 
-export const Option = styled.div`
+export const EventTarget = styled.div`
   display: flex;
   align-items: center;
   padding: 7px;
@@ -119,7 +119,7 @@ export const Option = styled.div`
   }
 `;
 
-export const RadioButton = styled.input`
+export const EventTargetRadioButton = styled.input`
   display: flex;
   justify-content: center;
   align-items: center;
@@ -139,20 +139,20 @@ export const RadioButton = styled.input`
   }
 `;
 
-export const TextContainer = styled.div`
+export const EventTargetWrapper = styled.div`
   display: flex;
   flex-direction: column;
   gap: 4px;
 `;
 
-export const OptionTitle = styled.p`
+export const EventTargetTitle = styled.p`
   font-size: 16px;
   font-weight: bold;
   line-height: 19px;
   color: #2c2d2e;
 `;
 
-export const OptionDescription = styled.span`
+export const EventTargetDescription = styled.span`
   font-size: 14px;
   color: #76787a;
 `;

--- a/src/pages/DashboardPage/DashboardInfoPage.style.jsx
+++ b/src/pages/DashboardPage/DashboardInfoPage.style.jsx
@@ -162,6 +162,7 @@ export const DateTimeContainer = styled.div`
   display: flex;
   align-items: center;
   padding-bottom: 6px;
+  width: 80%;
 `;
 
 export const DateTimeWrapper = styled.div`


### PR DESCRIPTION
## #️⃣ 관련 이슈

#113 

## 📝 작업 내용

- eventType 및 eventTarget 데이터 불러오는 API 연동
- 행사 기본 정보 페이지내 행사기간 날짜를 2 → 1개 띄우는 것으로 수정
- 이벤트 수정 API는 추후 재수정 예정 

## 📸 스크린샷
![image](https://github.com/user-attachments/assets/8b9c62f2-fe5a-4ff2-a481-610f10868f8f)
