### PR TITLE
#113 feat: 담당자 정보 불러오는 API 연동

### DIFF
--- a/src/pages/DashboardPage/DashboardPage.jsx
+++ b/src/pages/DashboardPage/DashboardPage.jsx
@@ -1,12 +1,12 @@
 import * as S from './DashboardPage.style';
-import { FaRotate, FaUsers } from 'react-icons/fa6';
 import React, { useState, useEffect } from 'react';
 import PageLayout from '../../Layout/PageLayout';
+import { FaRotate, FaUsers } from 'react-icons/fa6';
 import { Sidebar } from '../../components/Navigator';
 import { GrayButton90 } from '../../components/Button';
+import { USER_ID } from '../../constants';
 import { eventIDState } from '../../recoil/atoms/state';
 import { useRecoilValue } from 'recoil';
-import { USER_ID } from '../../constants';
 import { axiosInstance } from '../../axios';
 import { useNavigate } from 'react-router-dom';
 
@@ -90,9 +90,16 @@ export default function DashboardPage() {
           } else {
             setEventStatus('진행중');
           }
+
+          // 담당자 정보 설정
+          setContacts({
+            name: eventData.managerName || '',
+            phone: eventData.managerPhoneNumber || '',
+            email: eventData.managerEmail || '',
+          });
         }
       } catch (error) {
-        console.error('Error fetching event data:', error);
+        console.error('이벤트 데이터를 가져오는 중 오류:', error);
       }
     };
 

--- a/src/pages/DashboardPage/DashboardPage.jsx
+++ b/src/pages/DashboardPage/DashboardPage.jsx
@@ -232,7 +232,12 @@ export default function DashboardPage() {
 
               <S.ContentBox>
                 <S.ContentTitleWrapper>
-                  <S.ContentTitle>담당자</S.ContentTitle>
+                  <S.Tooltip>
+                    <S.ContentTitle>담당자</S.ContentTitle>
+                    <S.TooltipText className="tooltiptext">
+                      해당 연락처로 참석자들에게 문자와 메일이 발송됩니다.
+                    </S.TooltipText>
+                  </S.Tooltip>
                   <S.AddContactButton onClick={handleAddContact}>
                     {isEditing
                       ? '저장'

--- a/src/pages/DashboardPage/DashboardPage.jsx
+++ b/src/pages/DashboardPage/DashboardPage.jsx
@@ -234,7 +234,11 @@ export default function DashboardPage() {
                 <S.ContentTitleWrapper>
                   <S.ContentTitle>담당자</S.ContentTitle>
                   <S.AddContactButton onClick={handleAddContact}>
-                    {isEditing ? '저장' : '추가'}
+                    {isEditing
+                      ? '저장'
+                      : contacts.name || contacts.phone || contacts.email
+                        ? '수정'
+                        : '입력'}
                   </S.AddContactButton>
                 </S.ContentTitleWrapper>
                 <S.ContentInfoWrapper>

--- a/src/pages/DashboardPage/DashboardPage.style.jsx
+++ b/src/pages/DashboardPage/DashboardPage.style.jsx
@@ -363,3 +363,44 @@ export const ProgressText = styled.p`
   font-size: 20px;
   color: var(--gray-300, #636363);
 `;
+
+// 담당자 tooptip
+export const Tooltip = styled.div`
+  position: relative;
+  display: inline-block;
+
+  &:hover .tooltiptext {
+    visibility: visible;
+    opacity: 1;
+  }
+`;
+
+export const TooltipText = styled.div`
+  visibility: hidden;
+  background-color: #333;
+  color: #fff;
+  text-align: center;
+  font-size: 12px;
+  border-radius: 4px;
+  padding: 5px;
+  position: absolute;
+  z-index: 1;
+  top: 125%;
+  left: 0;
+  opacity: 0;
+  transition:
+    opacity 0.3s ease-in-out,
+    visibility 0.3s ease-in-out;
+  white-space: nowrap;
+
+  &::after {
+    content: '';
+    position: absolute;
+    bottom: 100%;
+    left: 20px;
+    margin-left: -5px;
+    border-width: 6px;
+    border-style: solid;
+    border-color: transparent transparent #333 transparent;
+  }
+`;


### PR DESCRIPTION
## #️⃣ 관련 이슈

#113

## 📝 작업 내용

- 담당자 정보 불러오는 API 연동
- 담당자 정보가 없으면 `입력`, 정보가 있으면 `수정`으로 버튼 내용 변경
  <img width="400" alt="image" src="https://github.com/user-attachments/assets/ca9d2d42-82aa-44e4-ab45-94e430fbfed2">
  <img width="400" alt="image" src="https://github.com/user-attachments/assets/33547849-9a72-4a46-ac7a-ce46d47235bb">

- 담당자 정보에 tooltip 구현
  <img width="400" alt="image" src="https://github.com/user-attachments/assets/574c1248-b4e6-4c7a-8a7f-5b6f2325bdee">

## 📸 스크린샷
![image](https://github.com/user-attachments/assets/6767488a-43b5-4a14-88b3-a51d84b28c55)
