### PR TITLE
#160 fix: 대시보드 및 기본 정보 페이지 내 eventType, eventTarget API 연동

### DIFF
--- a/src/pages/DashboardPage/DashboardAttendeePage.jsx
+++ b/src/pages/DashboardPage/DashboardAttendeePage.jsx
@@ -36,12 +36,12 @@ export default function DashboardAttendeePage() {
         );
         const eventData = response.data;
 
-        setEventTitle(eventData.eventTitle); // 이벤트 제목 설정
+        setEventTitle(eventData.eventTitle);
 
         const parsedSessions = eventData.eventSchedules.map(
           (schedule, index) => ({
             tab: index + 1,
-            date: schedule.eventDate,
+            date: `${schedule.eventDate.substring(5, 7)}/${schedule.eventDate.substring(8, 10)}`, // 'MM/DD' 형식으로 변경
             attendanceList: schedule.attendanceListResponseDtos,
           }),
         );
@@ -281,7 +281,6 @@ export default function DashboardAttendeePage() {
             <tbody>
               {attendees.map((data, index) => (
                 <tr key={index}>
-                  {' '}
                   <S.TableData>
                     <S.TelAnchor href={`tel:${data.phoneNumber}`}>
                       <FaPhone style={{ color: '#0075FF' }} />

--- a/src/pages/DashboardPage/DashboardEmailPage.jsx
+++ b/src/pages/DashboardPage/DashboardEmailPage.jsx
@@ -47,7 +47,7 @@ export default function DashboardEmailPage() {
         const event = response.data;
         const parsedSessions = event.eventSchedules.map((schedule, index) => ({
           tab: index + 1,
-          date: schedule.eventDate,
+          date: `${schedule.eventDate.substring(5, 7)}/${schedule.eventDate.substring(8, 10)}`,
           time: schedule.eventStartTime,
           attendanceList: schedule.attendanceListResponseDtos || [],
         }));

--- a/src/pages/DashboardPage/DashboardInfoPage.jsx
+++ b/src/pages/DashboardPage/DashboardInfoPage.jsx
@@ -43,8 +43,8 @@ export default function DashboardInfoPage() {
         );
         const eventData = response.data;
 
-        setEventType(eventData.eventType ? 'ONLINE' : 'OFFLINE');
-        setEventTarget(eventData.eventTarget || 'EXTERNAL : INTERNAL');
+        setEventType(eventData.eventType);
+        setEventTarget(eventData.eventTarget);
         setEventTitle(eventData.eventTitle);
         setEventDescription(eventData.eventDetail);
         setEventImage(eventData.eventImage || '');
@@ -61,8 +61,8 @@ export default function DashboardInfoPage() {
         );
 
         initialState.current = {
-          eventType: eventData.eventType ? 'ONLINE' : 'OFFLINE',
-          eventTarget: eventData.eventTarget || 'EXTERNAL : INTERNAL',
+          eventType: eventData.eventType,
+          eventTarget: eventData.eventTarget,
           eventTitle: eventData.eventTitle,
           eventDescription: eventData.eventDetail,
           eventImage: eventData.eventImage || '',
@@ -77,7 +77,7 @@ export default function DashboardInfoPage() {
           })),
         };
       } catch (error) {
-        console.error('Error fetching event data:', error);
+        console.error('이벤트 정보 불러오는 중 에러:', error);
       }
     };
 

--- a/src/pages/DashboardPage/DashboardPage.jsx
+++ b/src/pages/DashboardPage/DashboardPage.jsx
@@ -80,14 +80,19 @@ export default function DashboardPage() {
           setCompletedSessions(completedSessionsCount);
 
           // 행사 일정 상태
+          const firstSchedule = schedules[0];
           const lastSchedule = schedules[schedules.length - 1];
+
+          const firstScheduleStartDateTime = new Date(
+            `${firstSchedule.date}T${firstSchedule.startTime}`,
+          );
           const lastScheduleEndDateTime = new Date(
             `${lastSchedule.date}T${lastSchedule.endTime}`,
           );
 
-          if (lastScheduleEndDateTime < now) {
+          if (now > lastScheduleEndDateTime) {
             setEventStatus('종료');
-          } else if (new Date(lastSchedule.date) > now) {
+          } else if (now < firstScheduleStartDateTime) {
             setEventStatus('예정');
           } else {
             setEventStatus('진행중');

--- a/src/pages/DashboardPage/DashboardPage.jsx
+++ b/src/pages/DashboardPage/DashboardPage.jsx
@@ -71,6 +71,8 @@ export default function DashboardPage() {
             schedules,
             totalSessions: eventData.eventSchedules.length,
             totalParticipants,
+            eventType: eventData.eventType,
+            eventTarget: eventData.eventTarget,
           };
 
           setParsedEvents(parsedEvent);
@@ -126,6 +128,17 @@ export default function DashboardPage() {
       console.log(error);
     }
   };
+
+  // eventType, eventTarget
+  const getEventTypeLabel = (type) =>
+    type === 'OFFLINE' ? '오프라인' : type === 'ONLINE' ? '온라인' : type;
+
+  const getEventTargetLabel = (target) =>
+    target === 'EXTERNAL'
+      ? '외부인 (휴대폰번호로 출석체크)'
+      : target === 'INTERNAL'
+        ? '숙명여자대학교 학생 (학번으로 출석체크)'
+        : target;
 
   // 담당자 연락처 추가 및 입력 필드 생성
   const handleAddContact = async () => {
@@ -217,8 +230,12 @@ export default function DashboardPage() {
                 </S.ContentTitleWrapper>
                 <S.ContentInfoWrapper>
                   <S.EventTypeWrapper>
-                    <S.EventType>오프라인 행사</S.EventType>
-                    <S.EventVenue>캠퍼스 내부</S.EventVenue>
+                    <S.EventType>
+                      {getEventTypeLabel(parsedEvents.eventType)}
+                    </S.EventType>
+                    <S.EventTarget>
+                      {getEventTargetLabel(parsedEvents.eventTarget)}
+                    </S.EventTarget>
                   </S.EventTypeWrapper>
                   <S.EventDateWrapper>
                     {parsedEvents.schedules.map((schedule, index) => (

--- a/src/pages/DashboardPage/DashboardPage.style.jsx
+++ b/src/pages/DashboardPage/DashboardPage.style.jsx
@@ -327,7 +327,7 @@ export const ProgressBox = styled.div`
   background: #ffffff;
   width: 100%;
   border-radius: 10px;
-  gap: 18px;
+  gap: 8px;
 `;
 
 export const IconWrapper = styled.div`
@@ -346,18 +346,22 @@ export const IconWrapper = styled.div`
 export const ProgressContentWrapper = styled.div`
   display: flex;
   flex-direction: column;
+  justify-content: center;
+  align-items: center;
   gap: 2px;
 `;
 
 export const ProgressTitle = styled.h3`
+  margin-bottom: 2px;
   font-weight: 600;
   font-size: 12px;
   line-height: 100%;
   color: var(--blue-400, #0075ff);
-  margin-bottom: 2px;
 `;
 
 export const ProgressText = styled.p`
+  display: flex;
+  justify-content: center;
   width: 100px;
   font-weight: bold;
   font-size: 20px;

--- a/src/pages/DashboardPage/DashboardPage.style.jsx
+++ b/src/pages/DashboardPage/DashboardPage.style.jsx
@@ -266,7 +266,7 @@ export const EventTypeWrapper = styled.div`
   display: flex;
 `;
 
-export const EventType = styled.p`
+export const EventType = styled.span`
   padding-right: 12px;
   margin-right: 12px;
   border-right: 1px solid var(--gray-200, #d9d9d9);
@@ -275,7 +275,7 @@ export const EventType = styled.p`
   color: var(--blue-400, #0075ff);
 `;
 
-export const EventVenue = styled.p`
+export const EventTarget = styled.span`
   font-weight: 600;
   font-size: 14px;
   color: var(--blue-400, #0075ff);


### PR DESCRIPTION
## #️⃣ 관련 이슈

#160 

## 📝 작업 내용
- 대시보드 페이지 내 `평균 참석 인원` 및 `진행 회차` 간격 조정
- 대시보드 및 기본 정보 페이지 내 `eventType`, `eventTarget` API 연동
- 대시보드 타이틀 옆 뱃지 상태 수정
  - `예정`: ~ 첫번째 행사 전날
  - `진행중`: 첫번째 행사 당일~ 마지막날 행사 끝나는 시간
  - `종료`: 마지막날 행사 끝나는 시간 이후 ~
- 이메일 예약 발송, 참석자 관리 페이지 내 탭 정보 수정
  - `1회 (2024-07-24)` →  `1회 (07/24)`
 
## 📸 스크린샷
![image](https://github.com/user-attachments/assets/b9ee3c3a-d002-4ae5-b17a-fc502992dbff)

![image](https://github.com/user-attachments/assets/8f4879de-1d1d-4dab-86b4-812e9c21ab15)
