### PR TITLE
#183 feat: 참석자 명단을 담당자 메일로 자동 발송하는 기능 구현

### DIFF
--- a/src/constants/tempData.js
+++ b/src/constants/tempData.js
@@ -1,20 +1,8 @@
 // 테스트 코드
-export const USER_ID = 100;
-
-export const EVENT_ID = 1504;
-
-export const EVENT_DATE = '2024-07-12';
+// export const USER_ID = 100;
 
 // APPS
 // export const USER_ID = 300;
 
-// export const EVENT_ID = 2002;
-
-// export const EVENT_DATE = '2024-06-27';
-
 // 소중대
-// export const USER_ID = 500;
-
-// export const EVENT_ID = 2255;
-
-// export const EVENT_DATE = '2024-07-13';
+export const USER_ID = 500;

--- a/src/constants/tempData.js
+++ b/src/constants/tempData.js
@@ -1,9 +1,9 @@
 // 테스트 코드
-// export const USER_ID = 100;
+export const USER_ID = 100;
 
-// export const EVENT_ID = 1504;
+export const EVENT_ID = 1504;
 
-// export const EVENT_DATE = '2024-07-12';
+export const EVENT_DATE = '2024-07-12';
 
 // APPS
 // export const USER_ID = 300;
@@ -13,8 +13,8 @@
 // export const EVENT_DATE = '2024-06-27';
 
 // 소중대
-export const USER_ID = 500;
+// export const USER_ID = 500;
 
-export const EVENT_ID = 2255;
+// export const EVENT_ID = 2255;
 
-export const EVENT_DATE = '2024-07-13';
+// export const EVENT_DATE = '2024-07-13';

--- a/src/pages/DashboardPage/DashboardAttendeePage.jsx
+++ b/src/pages/DashboardPage/DashboardAttendeePage.jsx
@@ -169,6 +169,28 @@ export default function DashboardAttendeePage() {
     return <FaArrowDownShortWide />;
   };
 
+  // 출석 명단 메일로 전송
+  const handleSendEmail = async () => {
+    const isConfirmed = window.confirm(
+      '출석 명단을 이메일로 전송하시겠습니까?\n확인 버튼을 누르면 즉시 전송됩니다.',
+    );
+    if (!isConfirmed) {
+      return;
+    }
+    try {
+      const response = await axiosInstance.get(
+        `api/v1/attendance/list/${USER_ID}/${EVENT_ID}`,
+      );
+      if (response.status === 200) {
+        alert('전송이 완료됐습니다.');
+        console.log(response);
+      }
+    } catch (error) {
+      alert('전송에 실패했습니다.');
+      console.log(error);
+    }
+  };
+
   // 출석 명단 다운로드
   const handleDownload = async () => {
     try {
@@ -203,9 +225,10 @@ export default function DashboardAttendeePage() {
         <S.TopContainer>
           <S.Title>참석자 관리</S.Title>
           <S.ButtonContainer>
-            <S.DownBtn onClick={handleDownload}>
-              참석자 데이터 다운로드
+            <S.DownBtn onClick={handleSendEmail}>
+              출석 명단 메일로 전송
             </S.DownBtn>
+            <S.DownBtn onClick={handleDownload}>출석 명단 다운로드</S.DownBtn>
           </S.ButtonContainer>
         </S.TopContainer>
 

--- a/src/pages/DashboardPage/DashboardAttendeePage.style.jsx
+++ b/src/pages/DashboardPage/DashboardAttendeePage.style.jsx
@@ -196,6 +196,12 @@ export const TableData = styled.td`
     css`
       color: #f32121;
     `}
+
+  ${({ attendance }) =>
+    attendance === '출석' &&
+    css`
+      color: #28a745;
+    `}
 `;
 
 export const TelAnchor = styled.a`

--- a/src/pages/DashboardPage/DashboardAttendeePage.style.jsx
+++ b/src/pages/DashboardPage/DashboardAttendeePage.style.jsx
@@ -33,6 +33,7 @@ export const Title = styled.h1`
 
 export const ButtonContainer = styled.div`
   display: flex;
+  gap: 10px;
 `;
 
 export const DownBtn = styled.div`

--- a/src/pages/DashboardPage/DashboardPage.jsx
+++ b/src/pages/DashboardPage/DashboardPage.jsx
@@ -83,8 +83,8 @@ export default function DashboardPage() {
           const firstSchedule = schedules[0];
           const lastSchedule = schedules[schedules.length - 1];
 
-          const firstScheduleStartDateTime = new Date(
-            `${firstSchedule.date}T${firstSchedule.startTime}`,
+          const firstScheduleStartDate = new Date(
+            `${firstSchedule.date}T00:00:00`,
           );
           const lastScheduleEndDateTime = new Date(
             `${lastSchedule.date}T${lastSchedule.endTime}`,
@@ -92,9 +92,8 @@ export default function DashboardPage() {
 
           if (now > lastScheduleEndDateTime) {
             setEventStatus('종료');
-            // 행사 종료 후 출석 명단 전송
             await sendAttendanceList();
-          } else if (now < firstScheduleStartDateTime) {
+          } else if (now < firstScheduleStartDate) {
             setEventStatus('예정');
           } else {
             setEventStatus('진행중');

--- a/src/pages/DashboardPage/DashboardPage.jsx
+++ b/src/pages/DashboardPage/DashboardPage.jsx
@@ -92,6 +92,8 @@ export default function DashboardPage() {
 
           if (now > lastScheduleEndDateTime) {
             setEventStatus('종료');
+            // 행사 종료 후 출석 명단 전송
+            await sendAttendanceList();
           } else if (now < firstScheduleStartDateTime) {
             setEventStatus('예정');
           } else {
@@ -112,6 +114,21 @@ export default function DashboardPage() {
 
     fetchData();
   }, [EVENT_ID]);
+
+  const sendAttendanceList = async () => {
+    try {
+      const response = await axiosInstance.get(
+        `/api/v1/attendance/list/sending/${USER_ID}/${EVENT_ID}`,
+      );
+      if (response.data.isSuccess) {
+        console.log('출석 명단이 성공적으로 전송되었습니다.');
+      } else {
+        console.error('출석 명단 전송 실패:', response.data.message);
+      }
+    } catch (error) {
+      console.error('출석 명단 전송 중 오류:', error);
+    }
+  };
 
   // 행사 삭제
   const DeleteEvent = async () => {


### PR DESCRIPTION
## #️⃣ 관련 이슈

#183

## 📝 작업 내용

- 참석자 명단을 담당자 메일로 자동 발송하는 기능 구현
- `예정` 뱃지는 행사 당일 자정부터 변경되는것으로 수정
- 참석자 관리 페이지에서 `출석`이라면 글자색 초록으로 변경
- 참석자 관리 페이지 내 `출석 명단 메일로 전송` 버튼 생성 및 API 연동

## 📸 스크린샷
![image](https://github.com/user-attachments/assets/0db8657a-337a-4cbf-94f9-7aa0b8aece7a)