### PR TITLE
#229 fix: 대시보드 내 버튼 위치 조정

### DIFF
--- a/src/components/Button/Button.style.jsx
+++ b/src/components/Button/Button.style.jsx
@@ -1,3 +1,4 @@
+import { BREAKPOINTS } from '@/styles';
 import styled from 'styled-components';
 
 export const Button = styled.button`
@@ -10,4 +11,9 @@ export const Button = styled.button`
   color: ${(props) => props.textColor};
   font-size: 16px;
   font-weight: 600;
+
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    padding: 10px 18px;
+    font-size: 14px;
+  }
 `;

--- a/src/pages/DashboardPage/DashboardPage.style.jsx
+++ b/src/pages/DashboardPage/DashboardPage.style.jsx
@@ -22,7 +22,7 @@ export const TopContainer = styled.div`
   justify-content: space-between;
 
   @media (max-width: ${BREAKPOINTS[0]}px) {
-    margin-bottom: 10px;
+    flex-direction: column;
   }
 `;
 


### PR DESCRIPTION
## #️⃣ 관련 이슈

#229

<br>

## 📝 작업 내용

- 대시보드 내 버튼 위치 조정
- 모바일 반응형시 버튼 컴포넌트 크기 수정

<br>

## 📸 스크린샷

| 대시보드 (모바일 ver.)| 
|:----------------:|
|<img width='250' src='https://github.com/user-attachments/assets/0626ab3b-371c-4493-99bc-55d2a1bfc393'>|


<br>
