### PR TITLE
#227 design: 서명 페이지 디자인 수정

### DIFF
--- a/src/pages/AttendancePage/AttendanceSignPage.jsx
+++ b/src/pages/AttendancePage/AttendanceSignPage.jsx
@@ -89,20 +89,11 @@ const AttendanceSignPage = () => {
       <AttendanceHeader eventTitle={eventTitle} activeStep={1} />
 
       <S.ContentContainer>
-        <S.Title>
-          <strong>{studentName}</strong>님이 맞으십니까?
-        </S.Title>
         <S.StudentInfoContainer>
-          <S.Content>
-            <S.ContentTitle>소속</S.ContentTitle>
-            <S.ContentDescription>{major}</S.ContentDescription>
-          </S.Content>
-          {/* {eventTarget === 'INTERNAL' && (
-            <S.Content>
-              <S.ContentTitle>학번</S.ContentTitle>
-              <S.ContentDescription>{studentNumber}</S.ContentDescription>
-            </S.Content>
-          )} */}
+          <S.ContentDescription>{major}</S.ContentDescription>
+          <S.Title>
+            <strong>{studentName}</strong>님이 맞으십니까?
+          </S.Title>
         </S.StudentInfoContainer>
         {/* 서명 */}
         <S.CanvasWrapper>

--- a/src/pages/AttendancePage/AttendanceSignPage.jsx
+++ b/src/pages/AttendancePage/AttendanceSignPage.jsx
@@ -85,81 +85,81 @@ const AttendanceSignPage = () => {
   }, []);
 
   return (
-    <S.Container>
+    <S.AttendanceSignPage>
       <AttendanceHeader eventTitle={eventTitle} activeStep={1} />
-      <S.Title>
-        <strong>{studentName}</strong>님이 맞으십니까?
-      </S.Title>
+
       <S.ContentContainer>
-        <S.Content>
-          <S.ContentTitle>소속</S.ContentTitle>
-          <S.ContentDescription>{major}</S.ContentDescription>
-        </S.Content>
-        {eventTarget === 'INTERNAL' && (
+        <S.Title>
+          <strong>{studentName}</strong>님이 맞으십니까?
+        </S.Title>
+        <S.StudentInfoContainer>
           <S.Content>
-            <S.ContentTitle>학번</S.ContentTitle>
-            <S.ContentDescription>{studentNumber}</S.ContentDescription>
+            <S.ContentTitle>소속</S.ContentTitle>
+            <S.ContentDescription>{major}</S.ContentDescription>
           </S.Content>
+          {/* {eventTarget === 'INTERNAL' && (
+            <S.Content>
+              <S.ContentTitle>학번</S.ContentTitle>
+              <S.ContentDescription>{studentNumber}</S.ContentDescription>
+            </S.Content>
+          )} */}
+        </S.StudentInfoContainer>
+        {/* 서명 */}
+        <S.CanvasWrapper>
+          <S.SignatureResetButton
+            onClick={() => {
+              signatureRef.current.clear(); // 서명 리셋
+              setIsSigned(false);
+            }}
+          >
+            <FiRotateCcw color="#838383" size="28" />
+          </S.SignatureResetButton>
+          {!isSigned && (
+            <S.CanvasPlaceholder>
+              본인 확인을 위해, 서명을 입력해주세요.
+            </S.CanvasPlaceholder>
+          )}
+          <S.SignatureCanvasContainer>
+            <SignatureCanvas
+              penColor="black"
+              minWidth={4}
+              canvasProps={{
+                className: 'sigCanvas',
+                style: {
+                  borderRadius: '10px',
+                  backgroundColor: '#f0eeee',
+                },
+              }}
+              ref={signatureRef}
+              onEnd={handleSignature}
+            />
+          </S.SignatureCanvasContainer>
+        </S.CanvasWrapper>
+        {/* 버튼 */}
+        <S.ButtonContainer>
+          <S.CancelButton onClick={handleCancelButtonClick}>
+            본인이 아닙니다
+          </S.CancelButton>
+          <S.CompletedButton
+            onClick={handleCompletedButtonClick}
+            disabled={!isSigned}
+          >
+            입력 완료
+          </S.CompletedButton>
+        </S.ButtonContainer>
+        {/* 출석 완료 모달 */}
+        {isOpen && (
+          <>
+            <S.ModalOverlay />
+            <AttendanceConfirmModal
+              isOpen={isOpen}
+              name={studentName}
+              onClose={closeModal}
+            />
+          </>
         )}
       </S.ContentContainer>
-
-      {/* 서명 */}
-      <S.CanvasWrapper>
-        <S.SignatureResetButton
-          onClick={() => {
-            signatureRef.current.clear(); // 서명 리셋
-            setIsSigned(false);
-          }}
-        >
-          <FiRotateCcw color="#838383" size="28" />
-        </S.SignatureResetButton>
-        {!isSigned && (
-          <S.CanvasPlaceholder>
-            본인 확인을 위해, 서명을 입력해주세요.
-          </S.CanvasPlaceholder>
-        )}
-        <S.SignatureCanvasContainer>
-          <SignatureCanvas
-            penColor="black"
-            minWidth={4}
-            canvasProps={{
-              className: 'sigCanvas',
-              style: {
-                borderRadius: '4px',
-                backgroundColor: '#f0eeee',
-              },
-            }}
-            ref={signatureRef}
-            onEnd={handleSignature}
-          />
-        </S.SignatureCanvasContainer>
-      </S.CanvasWrapper>
-
-      {/* 버튼 */}
-      <S.ButtonContainer>
-        <S.CancelButton onClick={handleCancelButtonClick}>
-          본인이 아닙니다
-        </S.CancelButton>
-        <S.CompletedButton
-          onClick={handleCompletedButtonClick}
-          disabled={!isSigned}
-        >
-          입력 완료
-        </S.CompletedButton>
-      </S.ButtonContainer>
-
-      {/* 출석 완료 모달 */}
-      {isOpen && (
-        <>
-          <S.ModalOverlay />
-          <AttendanceConfirmModal
-            isOpen={isOpen}
-            name={studentName}
-            onClose={closeModal}
-          />
-        </>
-      )}
-    </S.Container>
+    </S.AttendanceSignPage>
   );
 };
 

--- a/src/pages/AttendancePage/AttendanceSignPage.style.jsx
+++ b/src/pages/AttendancePage/AttendanceSignPage.style.jsx
@@ -1,13 +1,31 @@
 import styled, { css } from 'styled-components';
-import { BREAKPOINTS } from '../../styles';
+import { BREAKPOINTS } from '@/styles';
 
-export const Container = styled.div`
+export const AttendanceSignPage = styled.div`
   display: flex;
   flex-direction: column;
   justify-items: center;
   align-items: center;
   height: 100vh;
   width: 100vw;
+  background-image: url('/img/background-attendance.svg');
+  background-size: cover;
+  background-position: center;
+`;
+
+export const ContentContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-items: center;
+  align-items: center;
+  width: 90%;
+  height: 100%;
+  border-radius: 20px;
+  background: var(--White, #fff);
+  box-shadow: 0px 4px 20px 0px rgba(0, 0, 0, 0.07);
+  margin-bottom: 20px;
+  padding: 30px 20px;
+  gap: 20px;
 `;
 
 export const Title = styled.h1`
@@ -15,9 +33,10 @@ export const Title = styled.h1`
   justify-content: center;
   align-items: center;
   width: 100%;
-  margin-top: 30px;
-  padding: 20px;
-  font-size: 40px;
+  font-size: 28px;
+  font-weight: 600;
+  text-align: center;
+  word-break: keep-all;
 
   & > strong {
     color: #0075ff;
@@ -30,13 +49,12 @@ export const Title = styled.h1`
   }
 `;
 
-export const ContentContainer = styled.div`
+export const StudentInfoContainer = styled.div`
   display: flex;
   justify-content: center;
   width: 100%;
   max-width: 900px;
   gap: 16px;
-  padding-bottom: 20px;
 
   @media (max-width: ${BREAKPOINTS[0]}px) {
     flex-direction: column;
@@ -106,10 +124,9 @@ export const CanvasPlaceholder = styled.p`
   top: 30px;
   left: 50%;
   transform: translate(-50%, -50%);
-  color: #838383;
+  color: var(--Black-2, #323232);
   text-align: center;
   font-size: 20px;
-  font-weight: 700;
 
   @media (max-width: ${BREAKPOINTS[0]}px) {
     top: 30px;
@@ -138,7 +155,6 @@ export const SignatureCanvasContainer = styled.div`
 export const ButtonContainer = styled.div`
   display: flex;
   gap: 20px;
-  padding: 20px 0 40px;
 
   @media (max-width: ${BREAKPOINTS[0]}px) {
     width: 100%;
@@ -151,11 +167,11 @@ export const ButtonContainer = styled.div`
 export const CancelButton = styled.button`
   width: 260px;
   height: 62px;
-  border-radius: 4px;
-  background: #838383;
+  border-radius: 10px;
+  background: var(--LG-3, #f2f2f2);
   font-size: 28px;
   font-weight: 600;
-  color: #ffffff;
+  color: var(--DG-2, #818181);
 
   @media (max-width: ${BREAKPOINTS[0]}px) {
     width: 100%;
@@ -167,7 +183,7 @@ export const CancelButton = styled.button`
 export const CompletedButton = styled.button`
   width: 360px;
   height: 62px;
-  border-radius: 4px;
+  border-radius: 10px;
   font-size: 28px;
   font-weight: 600;
   color: #ffffff;

--- a/src/pages/AttendancePage/AttendanceSignPage.style.jsx
+++ b/src/pages/AttendancePage/AttendanceSignPage.style.jsx
@@ -28,6 +28,18 @@ export const ContentContainer = styled.div`
   gap: 20px;
 `;
 
+export const StudentInfoContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  gap: 20px;
+
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+  }
+`;
+
 export const Title = styled.h1`
   display: flex;
   justify-content: center;
@@ -39,68 +51,20 @@ export const Title = styled.h1`
   word-break: keep-all;
 
   & > strong {
-    color: #0075ff;
-  }
-
-  @media (max-width: ${BREAKPOINTS[0]}px) {
-    font-size: 30px;
-    padding: 20px;
-    margin-top: 10px;
+    color: #2f7cef;
   }
 `;
 
-export const StudentInfoContainer = styled.div`
+export const ContentDescription = styled.div`
   display: flex;
   justify-content: center;
-  width: 100%;
-  max-width: 900px;
-  gap: 16px;
-
-  @media (max-width: ${BREAKPOINTS[0]}px) {
-    flex-direction: column;
-    padding: 10px;
-  }
-`;
-
-export const Content = styled.div`
-  display: flex;
-  width: 442px;
-  height: 50px;
-  font-size: 16px;
-  padding: 10px;
-  background-color: #f9f9f9;
-  align-items: center;
-  border-radius: 4px;
-
-  @media (max-width: ${BREAKPOINTS[0]}px) {
-    width: 100%;
-    height: 40px;
-    padding: 6px;
-  }
-`;
-
-export const ContentTitle = styled.span`
+  border-radius: 30px;
+  padding: 12px 26px;
+  background: #2f7cef;
   font-size: 20px;
-  font-weight: 700;
-  padding: 0 10px;
-  position: relative;
-
-  &::after {
-    content: '|';
-    position: absolute;
-    right: -15px;
-    color: #000;
-    font-weight: 400;
-  }
-
-  @media (max-width: ${BREAKPOINTS[0]}px) {
-    font-size: 16px;
-  }
-`;
-
-export const ContentDescription = styled.span`
-  padding: 0 30px;
-  font-size: 20px;
+  border: 1px solid #aecfff;
+  color: #fff;
+  white-space: nowrap;
 
   @media (max-width: ${BREAKPOINTS[0]}px) {
     font-size: 16px;
@@ -191,7 +155,7 @@ export const CompletedButton = styled.button`
   ${(props) =>
     props.disabled &&
     css`
-      background-color: #bddbff;
+      background-color: #aecfff;
       color: #ffffff;
       cursor: not-allowed;
     `}
@@ -199,7 +163,7 @@ export const CompletedButton = styled.button`
   ${(props) =>
     !props.disabled &&
     css`
-      background: #0075ff;
+      background: #2f7cef;
       cursor: pointer;
     `}
 

--- a/src/pages/AttendancePage/AttendanceSignPage.style.jsx
+++ b/src/pages/AttendancePage/AttendanceSignPage.style.jsx
@@ -99,10 +99,11 @@ export const CanvasPlaceholder = styled.p`
 `;
 
 export const SignatureCanvasContainer = styled.div`
-  width: 900px;
+  /* width: 100%; */
   /* max-width: 900px; */
   height: auto;
-  aspect-ratio: 900 / 400;
+  aspect-ratio: 900 / 300;
+  flex-grow: 1;
 
   canvas {
     width: 100%;
@@ -118,13 +119,13 @@ export const SignatureCanvasContainer = styled.div`
 
 export const ButtonContainer = styled.div`
   display: flex;
+  justify-content: center;
+  width: 100%;
   gap: 20px;
 
   @media (max-width: ${BREAKPOINTS[0]}px) {
     width: 100%;
     gap: 10px;
-    padding: 10px;
-    margin: 10px 0 20px;
   }
 `;
 
@@ -137,8 +138,12 @@ export const CancelButton = styled.button`
   font-weight: 600;
   color: var(--DG-2, #818181);
 
-  @media (max-width: ${BREAKPOINTS[0]}px) {
+  @media (max-width: ${BREAKPOINTS[1]}px) {
     width: 100%;
+    height: 50px;
+    font-size: 24px;
+  }
+  @media (max-width: ${BREAKPOINTS[0]}px) {
     height: 40px;
     font-size: 20px;
   }
@@ -167,8 +172,12 @@ export const CompletedButton = styled.button`
       cursor: pointer;
     `}
 
-    @media (max-width: ${BREAKPOINTS[0]}px) {
+  @media (max-width: ${BREAKPOINTS[1]}px) {
     width: 100%;
+    height: 50px;
+    font-size: 24px;
+  }
+  @media (max-width: ${BREAKPOINTS[0]}px) {
     height: 40px;
     font-size: 20px;
   }

--- a/src/pages/AttendancePage/AttendanceSignPage.style.jsx
+++ b/src/pages/AttendancePage/AttendanceSignPage.style.jsx
@@ -33,7 +33,7 @@ export const StudentInfoContainer = styled.div`
   justify-content: center;
   gap: 20px;
 
-  @media (max-width: ${BREAKPOINTS[0]}px) {
+  @media (max-width: ${BREAKPOINTS[1]}px) {
     flex-direction: column;
     justify-content: center;
     align-items: center;


### PR DESCRIPTION
## #️⃣ 관련 이슈

#227

<br>

## 📝 작업 내용

- 서명 페이지 디자인 수정
  - 본인 확인 문구 스타일 수정
  - canvas 라이브러리 및 버튼 크기 고정
  - 반응형 적용시 타이틀 줄바꿈 설정 
  - 교내 행사시에도 소속(전공)만 보여주는 형식으로 수정 (학번은 안보여줌)

<br>

## 📸 스크린샷

|     PC사이즈     |
| :----------------------: |
| <img width='600' src='https://github.com/user-attachments/assets/01a70509-b513-4733-a5d7-11b98f3d75fb'> |

|   모바일사이즈   |   
| :----------------------: | 
| <img width='250' src='https://github.com/user-attachments/assets/348f4154-793a-4809-9f31-4623fe098c26'> |


<br>
