### PR TITLE
#227 modify: 카카오톡 > 이메일 발송

### DIFF
--- a/src/components/Sidebar/Sidebar.jsx
+++ b/src/components/Sidebar/Sidebar.jsx
@@ -4,6 +4,7 @@ import {
   FaCircleInfo,
   FaUsers,
   FaChartPie,
+  FaEnvelopeCircleCheck,
 } from 'react-icons/fa6';
 import { useLocation } from 'react-router-dom';
 import { BiSolidMessageRounded } from 'react-icons/bi';
@@ -22,8 +23,8 @@ const menuItems = [
   },
   {
     to: '/event/dashboard/message',
-    icon: <BiSolidMessageRounded />,
-    text: '카카오톡 예약 발송',
+    icon: <FaEnvelopeCircleCheck />,
+    text: '이메일 예약 발송',
   },
   {
     to: '/event/dashboard/attendee',

--- a/src/constants/tempData.js
+++ b/src/constants/tempData.js
@@ -1,8 +1,8 @@
 // 테스트 코드
-// export const USER_ID = 100;
+export const USER_ID = 100;
 
 // APPS
-export const USER_ID = 300;
+// export const USER_ID = 300;
 
 // 소중대
 // export const USER_ID = 500;

--- a/src/pages/DashboardPage/DashboardMessagePage.jsx
+++ b/src/pages/DashboardPage/DashboardMessagePage.jsx
@@ -136,7 +136,7 @@ export default function DashboardMessagePage() {
     >
       <S.DashboardMessagePage>
         <S.TopContainer>
-          <S.Title>카카오톡 예약 발송</S.Title>
+          <S.Title>이메일 예약 발송</S.Title>
           <S.ButtonContainer>
             <Button label={'저장하기'} />
           </S.ButtonContainer>
@@ -162,9 +162,9 @@ export default function DashboardMessagePage() {
         <S.ContentContainer>
           <S.ToggleWrapper>
             <S.Content>
-              <S.ContentTitle>1시간 전 카카오톡 발송 여부</S.ContentTitle>
+              <S.ContentTitle>1시간 전 이메일 발송 여부</S.ContentTitle>
               <S.ContentDesc>
-                이벤트 시작 1시간 전에 카카오톡 메세지를 발송합니다.
+                이벤트 시작 1시간 전에 이메일을 발송합니다.
               </S.ContentDesc>
             </S.Content>
             <Switch


### PR DESCRIPTION
## #️⃣ 관련 이슈

#227

<br>

## 📝 작업 내용
- user id 100으로 수정

- `카카오톡` > `이메일` 발송

<br>

## 📸 스크린샷

|     PC사이즈내용입력     |
| :----------------------: |
| <img width='600' src='https://github.com/user-attachments/assets/9582fb8d-bd10-4666-8718-d3551337fa22'> |

<br>
