### PR TITLE
#234 feat: 세부 통계 페이지 임시 생성 후 더미데이터로 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@testing-library/user-event": "^13.5.0",
         "axios": "^1.6.8",
         "chart.js": "^4.4.4",
+        "chartjs-plugin-datalabels": "^2.2.0",
         "craco-alias": "^3.0.1",
         "date-fns": "^3.6.0",
         "moment": "^2.30.1",
@@ -6341,6 +6342,14 @@
       },
       "engines": {
         "pnpm": ">=8"
+      }
+    },
+    "node_modules/chartjs-plugin-datalabels": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/chartjs-plugin-datalabels/-/chartjs-plugin-datalabels-2.2.0.tgz",
+      "integrity": "sha512-14ZU30lH7n89oq+A4bWaJPnAG8a7ZTk7dKf48YAzMvJjQtjrgg5Dpk9f+LbjCF6bpx3RAGTeL13IXpKQYyRvlw==",
+      "peerDependencies": {
+        "chart.js": ">=3.0.0"
       }
     },
     "node_modules/check-types": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
         "axios": "^1.6.8",
+        "chart.js": "^4.4.4",
         "craco-alias": "^3.0.1",
         "date-fns": "^3.6.0",
         "moment": "^2.30.1",
@@ -3340,6 +3341,11 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.2.tgz",
+      "integrity": "sha512-fuscdXJ9G1qb7W8VdHi+IwRqij3lBkosAm4ydQtEmbY58OzHXqQhvlxqEkoz0yssNVn38bcpRWgA9PP+OGoisw=="
+    },
     "node_modules/@leichtgewicht/ip-codec": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
@@ -6323,6 +6329,17 @@
       "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.4.tgz",
+      "integrity": "sha512-emICKGBABnxhMjUjlYRR12PmOXhJ2eJjEHL2/dZlWjxRAZT1D8xplLFq5M0tMQK8ja+wBS/tuVEJB5C6r7VxJA==",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
       }
     },
     "node_modules/check-types": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "react-animated-numbers": "^0.18.0",
         "react-app-alias": "^2.2.2",
         "react-calendar": "^5.0.0",
+        "react-chartjs-2": "^5.2.0",
         "react-datepicker": "^7.2.0",
         "react-dom": "^18.3.1",
         "react-icons": "^5.2.1",
@@ -15565,6 +15566,15 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-chartjs-2": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.2.0.tgz",
+      "integrity": "sha512-98iN5aguJyVSxp5U3CblRLH67J8gkfyGNbiK3c+l1QI/G4irHMPQw44aEPmjVag+YKTyQ260NcF82GTQ3bdscA==",
+      "peerDependencies": {
+        "chart.js": "^4.1.1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-datepicker": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
     "axios": "^1.6.8",
+    "chart.js": "^4.4.4",
     "craco-alias": "^3.0.1",
     "date-fns": "^3.6.0",
     "moment": "^2.30.1",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "react-animated-numbers": "^0.18.0",
     "react-app-alias": "^2.2.2",
     "react-calendar": "^5.0.0",
+    "react-chartjs-2": "^5.2.0",
     "react-datepicker": "^7.2.0",
     "react-dom": "^18.3.1",
     "react-icons": "^5.2.1",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@testing-library/user-event": "^13.5.0",
     "axios": "^1.6.8",
     "chart.js": "^4.4.4",
+    "chartjs-plugin-datalabels": "^2.2.0",
     "craco-alias": "^3.0.1",
     "date-fns": "^3.6.0",
     "moment": "^2.30.1",

--- a/src/components/TopNavigation/TopNavigation.jsx
+++ b/src/components/TopNavigation/TopNavigation.jsx
@@ -60,6 +60,10 @@ export default function TopNavigation({ eventTitle } = {}) {
           <S.Menu to="/stats" activeClassName="active">
             통계
           </S.Menu>
+          {/* 세부 통계 페이지는 추후 통째로 삭제 */}
+          <S.Menu to="/stats/detail" activeClassName="active">
+            세부 통계(임시)
+          </S.Menu>
           {location.pathname.startsWith('/event/dashboard') && (
             <S.PageNameWrapper>
               {eventTitle !== undefined && (

--- a/src/pages/DetailStatisticsPage/DetailStatisticsPage.jsx
+++ b/src/pages/DetailStatisticsPage/DetailStatisticsPage.jsx
@@ -8,6 +8,12 @@ import { ATTENDEE_LIST } from './attendee';
 ChartJS.register(ArcElement, Tooltip, Legend);
 
 const DetailStatisticsPage = () => {
+  const startDate = ATTENDEE_LIST[0].eventSchedules[0].date.split('T')[0];
+  const endDate =
+    ATTENDEE_LIST[0].eventSchedules[
+      ATTENDEE_LIST[0].eventSchedules.length - 1
+    ].date.split('T')[0];
+
   // 학과 비율
   const departmentAttendance = {};
   ATTENDEE_LIST[0].eventSchedules.forEach((schedule) => {
@@ -105,7 +111,7 @@ const DetailStatisticsPage = () => {
           <S.TopContainer>
             <S.Title>행사별 통계</S.Title>
             <S.EventDate>
-              <span>통계 조사 기간</span>
+              {startDate} ~ {endDate}
             </S.EventDate>
           </S.TopContainer>
 

--- a/src/pages/DetailStatisticsPage/DetailStatisticsPage.jsx
+++ b/src/pages/DetailStatisticsPage/DetailStatisticsPage.jsx
@@ -32,21 +32,42 @@ const DetailStatisticsPage = () => {
   const sortedDepartmentAttendance = Object.entries(departmentAttendance).sort(
     (a, b) => b[1] - a[1],
   );
-  const departmentLabels = sortedDepartmentAttendance.map((item) => item[0]);
-  const departmentValues = sortedDepartmentAttendance.map((item) => item[1]);
+
+  const majorAttendanceLimit = 4;
+  const departmentLabels = sortedDepartmentAttendance
+    .slice(0, majorAttendanceLimit)
+    .map((item) => item[0]);
+
+  const etcValue = sortedDepartmentAttendance
+    .slice(majorAttendanceLimit)
+    .reduce((sum, item) => sum + item[1], 0);
+
+  if (etcValue > 0) {
+    departmentLabels.push('기타');
+  }
+
+  const departmentValues = sortedDepartmentAttendance
+    .slice(0, majorAttendanceLimit)
+    .map((item) => item[1]);
+
+  if (etcValue > 0) {
+    departmentValues.push(etcValue);
+  }
+
+  const departmentColors = departmentValues.map((_, index) => {
+    if (index < 4) {
+      return ['#2F7CEF', '#ACCDFF', '#2f7cef33', '#EDF5FF'][index];
+    } else {
+      return '#E4E4E4';
+    }
+  });
 
   const departmentData = {
     labels: departmentLabels,
     datasets: [
       {
         data: departmentValues,
-        backgroundColor: [
-          '#2F7CEF',
-          '#ACCDFF',
-          '#2f7cef33',
-          '#EDF5FF',
-          '#E4E4E4',
-        ],
+        backgroundColor: departmentColors,
       },
     ],
   };
@@ -69,21 +90,42 @@ const DetailStatisticsPage = () => {
   const sortedYearAttendance = Object.entries(yearAttendance).sort(
     (a, b) => b[1] - a[1],
   );
-  const yearLabels = sortedYearAttendance.map((item) => `${item[0]}학번`);
-  const yearValues = sortedYearAttendance.map((item) => item[1]);
+
+  const yearAttendanceLimit = 4;
+  const yearLabels = sortedYearAttendance
+    .slice(0, yearAttendanceLimit)
+    .map((item) => `${item[0]}학번`);
+
+  const etcYearValue = sortedYearAttendance
+    .slice(yearAttendanceLimit)
+    .reduce((sum, item) => sum + item[1], 0);
+
+  if (etcYearValue > 0) {
+    yearLabels.push('기타');
+  }
+
+  const yearValues = sortedYearAttendance
+    .slice(0, yearAttendanceLimit)
+    .map((item) => item[1]);
+
+  if (etcYearValue > 0) {
+    yearValues.push(etcYearValue);
+  }
+
+  const yearColors = yearValues.map((_, index) => {
+    if (index < 4) {
+      return ['#2F7CEF', '#ACCDFF', '#2f7cef33', '#EDF5FF'][index];
+    } else {
+      return '#E4E4E4';
+    }
+  });
 
   const yearData = {
     labels: yearLabels,
     datasets: [
       {
         data: yearValues,
-        backgroundColor: [
-          '#2F7CEF',
-          '#ACCDFF',
-          '#2f7cef33',
-          '#EDF5FF',
-          '#E4E4E4',
-        ],
+        backgroundColor: yearColors,
       },
     ],
   };

--- a/src/pages/DetailStatisticsPage/DetailStatisticsPage.jsx
+++ b/src/pages/DetailStatisticsPage/DetailStatisticsPage.jsx
@@ -29,7 +29,6 @@ const DetailStatisticsPage = () => {
     });
   });
 
-  // 학과별 참석 비율 정렬
   const sortedDepartmentAttendance = Object.entries(departmentAttendance).sort(
     (a, b) => b[1] - a[1],
   );
@@ -87,7 +86,6 @@ const DetailStatisticsPage = () => {
     });
   });
 
-  // 학번별 참석 비율 정렬
   const sortedYearAttendance = Object.entries(yearAttendance).sort(
     (a, b) => b[1] - a[1],
   );
@@ -127,6 +125,32 @@ const DetailStatisticsPage = () => {
       {
         data: yearValues,
         backgroundColor: yearColors,
+      },
+    ],
+  };
+
+  // 이수율 계산 로직
+  const totalStudents = ATTENDEE_LIST[0].eventSchedules.reduce(
+    (total, schedule) => total + schedule.students.length,
+    0,
+  );
+
+  const attendingStudents = ATTENDEE_LIST[0].eventSchedules.reduce(
+    (total, schedule) =>
+      total + schedule.students.filter((student) => student.isAttending).length,
+    0,
+  );
+
+  const completionRate = ((attendingStudents / totalStudents) * 100).toFixed(0);
+  const nonCompletionRate = (100 - completionRate).toFixed(0);
+
+  // 이수율 차트 데이터
+  const completionData = {
+    labels: ['이수', '미이수'],
+    datasets: [
+      {
+        data: [completionRate, nonCompletionRate],
+        backgroundColor: ['#2F7CEF', '#ACCDFF'],
       },
     ],
   };
@@ -175,6 +199,13 @@ const DetailStatisticsPage = () => {
               <S.ChartTitle>각 학번별 참석률</S.ChartTitle>
               <S.Chart>
                 <Doughnut data={yearData} options={options} />
+              </S.Chart>
+            </S.ChartWrapper>
+
+            <S.ChartWrapper>
+              <S.ChartTitle>전체 학생 중 이수율</S.ChartTitle>
+              <S.Chart>
+                <Doughnut data={completionData} options={options} />
               </S.Chart>
             </S.ChartWrapper>
           </S.ContentContainer>

--- a/src/pages/DetailStatisticsPage/DetailStatisticsPage.jsx
+++ b/src/pages/DetailStatisticsPage/DetailStatisticsPage.jsx
@@ -3,9 +3,10 @@ import { PageLayout } from '@/Layout';
 import { TopNavigation } from '@/components';
 import { Doughnut } from 'react-chartjs-2';
 import { Chart as ChartJS, ArcElement, Tooltip, Legend } from 'chart.js';
+import ChartDataLabels from 'chartjs-plugin-datalabels';
 import { ATTENDEE_LIST } from './attendee';
 
-ChartJS.register(ArcElement, Tooltip, Legend);
+ChartJS.register(ArcElement, Tooltip, Legend, ChartDataLabels);
 
 const DetailStatisticsPage = () => {
   const startDate = ATTENDEE_LIST[0].eventSchedules[0].date.split('T')[0];
@@ -134,6 +135,19 @@ const DetailStatisticsPage = () => {
     plugins: {
       legend: {
         position: 'right',
+      },
+      datalabels: {
+        color: '#000',
+        anchor: 'center',
+        align: 'center',
+        textAlign: 'center',
+
+        formatter: (value, context) => {
+          const total = context.dataset.data.reduce((acc, val) => acc + val, 0);
+          const percentage = ((value / total) * 100).toFixed(0);
+          const label = context.chart.data.labels[context.dataIndex];
+          return `${label} \n ${percentage}%`;
+        },
       },
     },
   };

--- a/src/pages/DetailStatisticsPage/DetailStatisticsPage.jsx
+++ b/src/pages/DetailStatisticsPage/DetailStatisticsPage.jsx
@@ -1,17 +1,121 @@
 import * as S from './DetailStatisticsPage.style';
 import { PageLayout } from '@/Layout';
 import { TopNavigation } from '@/components';
+import { Doughnut } from 'react-chartjs-2';
+import { Chart as ChartJS, ArcElement, Tooltip, Legend } from 'chart.js';
+import { ATTENDEE_LIST } from './attendee';
+
+ChartJS.register(ArcElement, Tooltip, Legend);
 
 const DetailStatisticsPage = () => {
+  // 학과 비율
+  const departmentAttendance = {};
+  ATTENDEE_LIST[0].eventSchedules.forEach((schedule) => {
+    schedule.students.forEach((student) => {
+      if (student.isAttending) {
+        if (departmentAttendance[student.major]) {
+          departmentAttendance[student.major]++;
+        } else {
+          departmentAttendance[student.major] = 1;
+        }
+      }
+    });
+  });
+
+  // 학번별 참석률
+  const yearAttendance = {};
+  ATTENDEE_LIST[0].eventSchedules.forEach((schedule) => {
+    schedule.students.forEach((student) => {
+      if (student.isAttending) {
+        if (yearAttendance[student.studentYear]) {
+          yearAttendance[student.studentYear]++;
+        } else {
+          yearAttendance[student.studentYear] = 1;
+        }
+      }
+    });
+  });
+
+  // 학과별 참석률
+  const departmentData = {
+    labels: Object.keys(departmentAttendance),
+    datasets: [
+      {
+        data: Object.values(departmentAttendance),
+        backgroundColor: [
+          'rgba(255, 99, 132, 0.2)',
+          'rgba(54, 162, 235, 0.2)',
+          'rgba(255, 206, 86, 0.2)',
+          'rgba(75, 192, 192, 0.2)',
+          'rgba(153, 102, 255, 0.2)',
+          'rgba(255, 159, 64, 0.2)',
+        ],
+        borderColor: [
+          'rgba(255, 99, 132, 1)',
+          'rgba(54, 162, 235, 1)',
+          'rgba(255, 206, 86, 1)',
+          'rgba(75, 192, 192, 1)',
+          'rgba(153, 102, 255, 1)',
+          'rgba(255, 159, 64, 1)',
+        ],
+        borderWidth: 1,
+      },
+    ],
+  };
+
+  // 학번별 참석률
+  const yearData = {
+    labels: Object.keys(yearAttendance).map((year) => `${year}학번`),
+    datasets: [
+      {
+        data: Object.values(yearAttendance),
+        backgroundColor: [
+          'rgba(255, 99, 132, 0.2)',
+          'rgba(54, 162, 235, 0.2)',
+          'rgba(255, 206, 86, 0.2)',
+          'rgba(75, 192, 192, 0.2)',
+          'rgba(153, 102, 255, 0.2)',
+          'rgba(255, 159, 64, 0.2)',
+        ],
+        borderColor: [
+          'rgba(255, 99, 132, 1)',
+          'rgba(54, 162, 235, 1)',
+          'rgba(255, 206, 86, 1)',
+          'rgba(75, 192, 192, 1)',
+          'rgba(153, 102, 255, 1)',
+          'rgba(255, 159, 64, 1)',
+        ],
+        borderWidth: 1,
+      },
+    ],
+  };
+
   return (
     <PageLayout topNavigation={<TopNavigation />}>
       <S.Container>
         <S.DetailStatisticsPage>
           <S.TopContainer>
             <S.Title>행사별 통계</S.Title>
+            <S.EventDate>
+              <span>통계 조사 기간</span>
+            </S.EventDate>
           </S.TopContainer>
 
-          <S.ContentContainer></S.ContentContainer>
+          <S.ContentContainer>
+            <S.ChartWrapper>
+              <S.ChartTitle>행사에 참석한 학과 비율</S.ChartTitle>
+              <S.Chart>
+                <Doughnut data={departmentData} />
+              </S.Chart>
+            </S.ChartWrapper>
+
+            <S.ChartWrapper>
+              <S.ChartTitle>각 학번별 참석률</S.ChartTitle>
+              <S.Chart>
+                <Doughnut data={yearData} />
+              </S.Chart>
+            </S.ChartWrapper>
+          </S.ContentContainer>
         </S.DetailStatisticsPage>
       </S.Container>
     </PageLayout>

--- a/src/pages/DetailStatisticsPage/DetailStatisticsPage.jsx
+++ b/src/pages/DetailStatisticsPage/DetailStatisticsPage.jsx
@@ -63,6 +63,14 @@ const DetailStatisticsPage = () => {
     ],
   };
 
+  const options = {
+    plugins: {
+      legend: {
+        position: 'right',
+      },
+    },
+  };
+
   // 학번별 참석률
   const yearData = {
     labels: Object.keys(yearAttendance).map((year) => `${year}학번`),
@@ -105,14 +113,14 @@ const DetailStatisticsPage = () => {
             <S.ChartWrapper>
               <S.ChartTitle>행사에 참석한 학과 비율</S.ChartTitle>
               <S.Chart>
-                <Doughnut data={departmentData} />
+                <Doughnut data={departmentData} options={options} />
               </S.Chart>
             </S.ChartWrapper>
 
             <S.ChartWrapper>
               <S.ChartTitle>각 학번별 참석률</S.ChartTitle>
               <S.Chart>
-                <Doughnut data={yearData} />
+                <Doughnut data={yearData} options={options} />
               </S.Chart>
             </S.ChartWrapper>
           </S.ContentContainer>

--- a/src/pages/DetailStatisticsPage/DetailStatisticsPage.jsx
+++ b/src/pages/DetailStatisticsPage/DetailStatisticsPage.jsx
@@ -87,7 +87,7 @@ const DetailStatisticsPage = () => {
   });
 
   const sortedYearAttendance = Object.entries(yearAttendance).sort(
-    (a, b) => b[1] - a[1],
+    (a, b) => b[0] - a[0],
   );
 
   const yearAttendanceLimit = 4;

--- a/src/pages/DetailStatisticsPage/DetailStatisticsPage.jsx
+++ b/src/pages/DetailStatisticsPage/DetailStatisticsPage.jsx
@@ -159,6 +159,11 @@ const DetailStatisticsPage = () => {
     plugins: {
       legend: {
         position: 'right',
+        labels: {
+          usePointStyle: true,
+          padding: 20,
+          boxWidth: 10,
+        },
       },
       datalabels: {
         color: '#000',
@@ -172,6 +177,11 @@ const DetailStatisticsPage = () => {
           const label = context.chart.data.labels[context.dataIndex];
           return `${label} \n ${percentage}%`;
         },
+      },
+    },
+    layout: {
+      padding: {
+        right: 10,
       },
     },
   };

--- a/src/pages/DetailStatisticsPage/DetailStatisticsPage.jsx
+++ b/src/pages/DetailStatisticsPage/DetailStatisticsPage.jsx
@@ -14,7 +14,7 @@ const DetailStatisticsPage = () => {
       ATTENDEE_LIST[0].eventSchedules.length - 1
     ].date.split('T')[0];
 
-  // 학과 비율
+  // 학과별 참석 비율을 계산하는 로직
   const departmentAttendance = {};
   ATTENDEE_LIST[0].eventSchedules.forEach((schedule) => {
     schedule.students.forEach((student) => {
@@ -28,7 +28,30 @@ const DetailStatisticsPage = () => {
     });
   });
 
-  // 학번별 참석률
+  // 학과별 참석 비율 정렬
+  const sortedDepartmentAttendance = Object.entries(departmentAttendance).sort(
+    (a, b) => b[1] - a[1],
+  );
+  const departmentLabels = sortedDepartmentAttendance.map((item) => item[0]);
+  const departmentValues = sortedDepartmentAttendance.map((item) => item[1]);
+
+  const departmentData = {
+    labels: departmentLabels,
+    datasets: [
+      {
+        data: departmentValues,
+        backgroundColor: [
+          '#2F7CEF',
+          '#ACCDFF',
+          '#2f7cef33',
+          '#EDF5FF',
+          '#E4E4E4',
+        ],
+      },
+    ],
+  };
+
+  // 학번별 참석 비율을 계산하는 로직
   const yearAttendance = {};
   ATTENDEE_LIST[0].eventSchedules.forEach((schedule) => {
     schedule.students.forEach((student) => {
@@ -42,29 +65,25 @@ const DetailStatisticsPage = () => {
     });
   });
 
-  // 학과별 참석률
-  const departmentData = {
-    labels: Object.keys(departmentAttendance),
+  // 학번별 참석 비율 정렬
+  const sortedYearAttendance = Object.entries(yearAttendance).sort(
+    (a, b) => b[1] - a[1],
+  );
+  const yearLabels = sortedYearAttendance.map((item) => `${item[0]}학번`);
+  const yearValues = sortedYearAttendance.map((item) => item[1]);
+
+  const yearData = {
+    labels: yearLabels,
     datasets: [
       {
-        data: Object.values(departmentAttendance),
+        data: yearValues,
         backgroundColor: [
-          'rgba(255, 99, 132, 0.2)',
-          'rgba(54, 162, 235, 0.2)',
-          'rgba(255, 206, 86, 0.2)',
-          'rgba(75, 192, 192, 0.2)',
-          'rgba(153, 102, 255, 0.2)',
-          'rgba(255, 159, 64, 0.2)',
+          '#2F7CEF',
+          '#ACCDFF',
+          '#2f7cef33',
+          '#EDF5FF',
+          '#E4E4E4',
         ],
-        borderColor: [
-          'rgba(255, 99, 132, 1)',
-          'rgba(54, 162, 235, 1)',
-          'rgba(255, 206, 86, 1)',
-          'rgba(75, 192, 192, 1)',
-          'rgba(153, 102, 255, 1)',
-          'rgba(255, 159, 64, 1)',
-        ],
-        borderWidth: 1,
       },
     ],
   };
@@ -75,33 +94,6 @@ const DetailStatisticsPage = () => {
         position: 'right',
       },
     },
-  };
-
-  // 학번별 참석률
-  const yearData = {
-    labels: Object.keys(yearAttendance).map((year) => `${year}학번`),
-    datasets: [
-      {
-        data: Object.values(yearAttendance),
-        backgroundColor: [
-          'rgba(255, 99, 132, 0.2)',
-          'rgba(54, 162, 235, 0.2)',
-          'rgba(255, 206, 86, 0.2)',
-          'rgba(75, 192, 192, 0.2)',
-          'rgba(153, 102, 255, 0.2)',
-          'rgba(255, 159, 64, 0.2)',
-        ],
-        borderColor: [
-          'rgba(255, 99, 132, 1)',
-          'rgba(54, 162, 235, 1)',
-          'rgba(255, 206, 86, 1)',
-          'rgba(75, 192, 192, 1)',
-          'rgba(153, 102, 255, 1)',
-          'rgba(255, 159, 64, 1)',
-        ],
-        borderWidth: 1,
-      },
-    ],
   };
 
   return (

--- a/src/pages/DetailStatisticsPage/DetailStatisticsPage.jsx
+++ b/src/pages/DetailStatisticsPage/DetailStatisticsPage.jsx
@@ -1,0 +1,21 @@
+import * as S from './DetailStatisticsPage.style';
+import { PageLayout } from '@/Layout';
+import { TopNavigation } from '@/components';
+
+const DetailStatisticsPage = () => {
+  return (
+    <PageLayout topNavigation={<TopNavigation />}>
+      <S.Container>
+        <S.DetailStatisticsPage>
+          <S.TopContainer>
+            <S.Title>행사별 통계</S.Title>
+          </S.TopContainer>
+
+          <S.ContentContainer></S.ContentContainer>
+        </S.DetailStatisticsPage>
+      </S.Container>
+    </PageLayout>
+  );
+};
+
+export default DetailStatisticsPage;

--- a/src/pages/DetailStatisticsPage/DetailStatisticsPage.style.jsx
+++ b/src/pages/DetailStatisticsPage/DetailStatisticsPage.style.jsx
@@ -70,7 +70,7 @@ export const Chart = styled.div`
   border-radius: 20px;
   border: 1px solid #aecfff;
   background: #fff;
-  padding: 20px 30px;
+  padding: 0 30px;
   width: 100%;
   height: 100%;
   max-height: 300px;

--- a/src/pages/DetailStatisticsPage/DetailStatisticsPage.style.jsx
+++ b/src/pages/DetailStatisticsPage/DetailStatisticsPage.style.jsx
@@ -14,7 +14,6 @@ export const DetailStatisticsPage = styled.div`
   max-width: 1100px;
   margin: 0 auto;
   padding: 50px 20px;
-  gap: 30px;
 
   border: 1px solid red; /* 임시 코드 */
 `;
@@ -46,16 +45,26 @@ export const EventDate = styled.p`
 // 통계
 export const ContentContainer = styled.div`
   display: flex;
-  flex-direction: column;
-  width: 500px;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  width: 100%;
   gap: 32px;
   padding-top: 20px;
+
+  @media (max-width: ${BREAKPOINTS[1]}px) {
+    flex-direction: column;
+  }
 `;
 
 export const ChartWrapper = styled.div`
   display: flex;
   flex-direction: column;
   gap: 10px;
+  width: calc(50% - 16px);
+
+  @media (max-width: ${BREAKPOINTS[1]}px) {
+    width: 100%;
+  }
 `;
 
 export const ChartTitle = styled.h2`

--- a/src/pages/DetailStatisticsPage/DetailStatisticsPage.style.jsx
+++ b/src/pages/DetailStatisticsPage/DetailStatisticsPage.style.jsx
@@ -66,9 +66,14 @@ export const ChartTitle = styled.h2`
 `;
 
 export const Chart = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
   border-radius: 20px;
   border: 1px solid #aecfff;
   background: #fff;
-  padding: 55px 48px;
-  height: 300px;
+  padding: 20px 30px;
+  width: 100%;
+  height: 100%;
+  max-height: 300px;
 `;

--- a/src/pages/DetailStatisticsPage/DetailStatisticsPage.style.jsx
+++ b/src/pages/DetailStatisticsPage/DetailStatisticsPage.style.jsx
@@ -39,10 +39,8 @@ export const Title = styled.h1`
 export const EventDate = styled.p`
   font-size: 14px;
   margin-bottom: 2px;
-
-  & > span {
-    font-weight: 600;
-  }
+  color: #6b6b6b;
+  font-weight: 500;
 `;
 
 // 통계

--- a/src/pages/DetailStatisticsPage/DetailStatisticsPage.style.jsx
+++ b/src/pages/DetailStatisticsPage/DetailStatisticsPage.style.jsx
@@ -1,0 +1,45 @@
+import { BREAKPOINTS } from '@/styles';
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+`;
+
+export const DetailStatisticsPage = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 50px 20px;
+  gap: 30px;
+
+  border: 1px solid red; /* 임시 코드 */
+`;
+
+// 행사 타이틀 + 버튼
+export const TopContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 20px;
+
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    margin-bottom: 10px;
+  }
+`;
+
+export const Title = styled.h1`
+  font-size: 24px;
+  font-weight: bold;
+`;
+
+// 통계
+export const ContentContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 500px;
+  gap: 32px;
+  padding-top: 20px;
+`;

--- a/src/pages/DetailStatisticsPage/DetailStatisticsPage.style.jsx
+++ b/src/pages/DetailStatisticsPage/DetailStatisticsPage.style.jsx
@@ -22,8 +22,9 @@ export const DetailStatisticsPage = styled.div`
 // 행사 타이틀 + 버튼
 export const TopContainer = styled.div`
   display: flex;
-  justify-content: space-between;
   margin-bottom: 20px;
+  gap: 10px;
+  align-items: flex-end;
 
   @media (max-width: ${BREAKPOINTS[0]}px) {
     margin-bottom: 10px;
@@ -35,6 +36,15 @@ export const Title = styled.h1`
   font-weight: bold;
 `;
 
+export const EventDate = styled.p`
+  font-size: 14px;
+  margin-bottom: 2px;
+
+  & > span {
+    font-weight: 600;
+  }
+`;
+
 // 통계
 export const ContentContainer = styled.div`
   display: flex;
@@ -42,4 +52,23 @@ export const ContentContainer = styled.div`
   width: 500px;
   gap: 32px;
   padding-top: 20px;
+`;
+
+export const ChartWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+`;
+
+export const ChartTitle = styled.h2`
+  font-size: 18px;
+  font-weight: 600;
+`;
+
+export const Chart = styled.div`
+  border-radius: 20px;
+  border: 1px solid #aecfff;
+  background: #fff;
+  padding: 55px 48px;
+  height: 300px;
 `;

--- a/src/pages/DetailStatisticsPage/attendee.js
+++ b/src/pages/DetailStatisticsPage/attendee.js
@@ -51,6 +51,11 @@ export const ATTENDEE_LIST = [
             studentYear: 24,
             isAttending: true,
           },
+          {
+            major: '의상학과',
+            studentYear: 20,
+            isAttending: true,
+          },
         ],
       },
       {
@@ -101,6 +106,11 @@ export const ATTENDEE_LIST = [
             studentYear: 24,
             isAttending: false,
           },
+          {
+            major: '의상학과',
+            studentYear: 20,
+            isAttending: true,
+          },
         ],
       },
       {
@@ -150,6 +160,11 @@ export const ATTENDEE_LIST = [
             major: '수학과',
             studentYear: 24,
             isAttending: false,
+          },
+          {
+            major: '의상학과',
+            studentYear: 20,
+            isAttending: true,
           },
         ],
       },

--- a/src/pages/DetailStatisticsPage/attendee.js
+++ b/src/pages/DetailStatisticsPage/attendee.js
@@ -1,0 +1,159 @@
+export const ATTENDEE_LIST = [
+  {
+    eventId: 0,
+    eventTitle: 'string',
+    eventSchedules: [
+      {
+        date: '2024-09-11T12:18:40.472Z',
+        students: [
+          {
+            major: '소프트웨어응용학전공',
+            studentYear: 21,
+            isAttending: true,
+          },
+          {
+            major: '컴퓨터과학전공',
+            studentYear: 21,
+            isAttending: false,
+          },
+          {
+            major: '컴퓨터과학전공',
+            studentYear: 22,
+            isAttending: true,
+          },
+          {
+            major: '경영학과',
+            studentYear: 23,
+            isAttending: true,
+          },
+          {
+            major: '경영학과',
+            studentYear: 23,
+            isAttending: false,
+          },
+          {
+            major: '통계학과',
+            studentYear: 24,
+            isAttending: true,
+          },
+          {
+            major: '통계학과',
+            studentYear: 24,
+            isAttending: true,
+          },
+          {
+            major: '통계학과',
+            studentYear: 24,
+            isAttending: false,
+          },
+          {
+            major: '수학과',
+            studentYear: 24,
+            isAttending: true,
+          },
+        ],
+      },
+      {
+        date: '2024-09-12T12:18:40.472Z',
+        students: [
+          {
+            major: '소프트웨어응용학전공',
+            studentYear: 21,
+            isAttending: true,
+          },
+          {
+            major: '컴퓨터과학전공',
+            studentYear: 21,
+            isAttending: false,
+          },
+          {
+            major: '컴퓨터과학전공',
+            studentYear: 22,
+            isAttending: true,
+          },
+          {
+            major: '경영학과',
+            studentYear: 23,
+            isAttending: false,
+          },
+          {
+            major: '경영학과',
+            studentYear: 23,
+            isAttending: true,
+          },
+          {
+            major: '통계학과',
+            studentYear: 24,
+            isAttending: true,
+          },
+          {
+            major: '통계학과',
+            studentYear: 24,
+            isAttending: false,
+          },
+          {
+            major: '통계학과',
+            studentYear: 24,
+            isAttending: true,
+          },
+          {
+            major: '수학과',
+            studentYear: 24,
+            isAttending: false,
+          },
+        ],
+      },
+      {
+        date: '2024-09-13T12:18:40.472Z',
+        students: [
+          {
+            major: '소프트웨어응용학전공',
+            studentYear: 21,
+            isAttending: false,
+          },
+          {
+            major: '컴퓨터과학전공',
+            studentYear: 21,
+            isAttending: true,
+          },
+          {
+            major: '컴퓨터과학전공',
+            studentYear: 22,
+            isAttending: true,
+          },
+          {
+            major: '경영학과',
+            studentYear: 23,
+            isAttending: true,
+          },
+          {
+            major: '경영학과',
+            studentYear: 23,
+            isAttending: false,
+          },
+          {
+            major: '통계학과',
+            studentYear: 24,
+            isAttending: true,
+          },
+          {
+            major: '통계학과',
+            studentYear: 24,
+            isAttending: false,
+          },
+          {
+            major: '통계학과',
+            studentYear: 24,
+            isAttending: true,
+          },
+          {
+            major: '수학과',
+            studentYear: 24,
+            isAttending: false,
+          },
+        ],
+      },
+    ],
+    eventImage: 'string',
+  },
+];

--- a/src/pages/DetailStatisticsPage/index.js
+++ b/src/pages/DetailStatisticsPage/index.js
@@ -1,0 +1,1 @@
+export { default as DetailStatisticsPage } from './DetailStatisticsPage';

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -12,3 +12,5 @@ export { EventCardListPage } from './EventCardListPage';
 export { TotalStatisticsPage } from './TotalStatisticsPage';
 export { LoadingPage } from './LoadingPage';
 export { RegisterCompleted } from './RegisterPage';
+// 추후 삭제
+export { DetailStatisticsPage } from './DetailStatisticsPage';

--- a/src/router.js
+++ b/src/router.js
@@ -13,6 +13,7 @@ import {
   DashboardStatisticPage,
   LoadingPage,
   RegisterCompleted,
+  DetailStatisticsPage,
 } from './pages';
 import Layout from './Layout/Layout';
 
@@ -59,6 +60,10 @@ const router = createBrowserRouter([
       {
         path: '/stats',
         element: <TotalStatisticsPage />,
+      },
+      {
+        path: '/stats/detail',
+        element: <DetailStatisticsPage />,
       },
       {
         path: '/loading',


### PR DESCRIPTION
## #️⃣ 관련 이슈

#234

<br>

## 📝 작업 내용

- 세부 통계 페이지 임시 생성 후 더미데이터로 구현
- 이수율은 추후 수정 필요

<br>

## 📸 스크린샷

|     세부 통계     |
| :----------------------: |
| <img width='600' src='https://github.com/user-attachments/assets/33c90dcc-591a-40eb-985c-f0dbc4921514'> |


|   모바일사이즈내용입력   |  
| :----------------------: | 
| <img width='250' src='https://github.com/user-attachments/assets/72854ac6-92df-4d71-afdc-106bd7ec0ac6'> |


<br>
