### PR TITLE
#235 feat: 전체, 진행중, 종료를 쿼리로 구현

### DIFF
--- a/src/Pages/EventCardListPage/EventCardListPage.jsx
+++ b/src/Pages/EventCardListPage/EventCardListPage.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import * as S from './EventCardListPage.style';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router-dom';
 import { axiosInstance } from '@/axios';
 import { EventCard, Dropdown, TopNavigation, Search } from '@/components';
 import { PageLayout } from '@/Layout';

--- a/src/Pages/EventCardListPage/EventCardListPage.jsx
+++ b/src/Pages/EventCardListPage/EventCardListPage.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import * as S from './EventCardListPage.style';
-// import { USER_ID } from '@/constants';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { axiosInstance } from '@/axios';
 import { EventCard, Dropdown, TopNavigation, Search } from '@/components';
 import { PageLayout } from '@/Layout';
@@ -9,8 +9,10 @@ const EventCardListPage = () => {
   const USER_ID = sessionStorage.getItem('id');
   const [events, setEvents] = useState([]);
   const [filteredEvents, setFilteredEvents] = useState([]);
-  const [selectedFilter, setSelectedFilter] = useState('전체');
   const [searchTerm, setSearchTerm] = useState('');
+
+  const [searchParams, setSearchParams] = useSearchParams();
+  const selectedFilter = searchParams.get('status') || '전체'; // 기본값이 전체
 
   useEffect(() => {
     const fetchData = async () => {
@@ -34,7 +36,7 @@ const EventCardListPage = () => {
               ? new Date() > new Date(endDate)
                 ? '마감'
                 : '진행중'
-              : '진행중', // 현재 날짜와 비교해 상태 결정
+              : '진행중',
           };
         });
 
@@ -52,7 +54,7 @@ const EventCardListPage = () => {
       }
     };
     fetchData();
-  }, []);
+  }, [USER_ID]);
 
   useEffect(() => {
     const filtered = events.filter((event) => {
@@ -68,7 +70,7 @@ const EventCardListPage = () => {
   }, [selectedFilter, events, searchTerm]);
 
   const handleFilterChange = (filter) => {
-    setSelectedFilter(filter);
+    setSearchParams({ status: filter });
   };
 
   const handleSearch = (searchTerm) => {
@@ -81,7 +83,7 @@ const EventCardListPage = () => {
         <div style={{ display: 'flex', justifyContent: 'space-between' }}>
           <Dropdown
             items={['전체', '진행중', '마감']}
-            defaultItem="전체"
+            defaultItem={selectedFilter}
             onSelect={handleFilterChange}
           />
           <Search onSearch={handleSearch} />

--- a/src/components/Dropdown/Dropdown.style.jsx
+++ b/src/components/Dropdown/Dropdown.style.jsx
@@ -31,7 +31,6 @@ export const DropdownButton = styled.button`
 export const DropdownContent = styled.ul`
   display: flex;
   flex-direction: column;
-
   position: absolute;
   z-index: 1000;
   top: 100%;
@@ -41,7 +40,7 @@ export const DropdownContent = styled.ul`
   border-radius: 7px;
   background: #f4f8ff;
   padding: 4px;
-  width: 100;
+  min-width: max-content;
   box-shadow: 4px 4px 4px 0px rgba(0, 0, 0, 0.1);
   list-style: none;
 `;

--- a/src/components/Sidebar/Sidebar.jsx
+++ b/src/components/Sidebar/Sidebar.jsx
@@ -32,7 +32,7 @@ const menuItems = [
     text: '참석자 관리',
   },
   {
-    to: '/event/dashboard/stats',
+    to: '/event/dashboard/statistic',
     icon: <FaChartPie />,
     text: '통계',
   },

--- a/src/components/TopNavigation/TopNavigation.jsx
+++ b/src/components/TopNavigation/TopNavigation.jsx
@@ -79,10 +79,10 @@ export default function TopNavigation({ eventTitle } = {}) {
           <S.Menu to="/register" activeClassName="active">
             행사 등록
           </S.Menu>
-          <S.Menu to="/event" activeClassName="active">
+          <S.Menu to="/events" activeClassName="active">
             행사 목록
           </S.Menu>
-          <S.Menu to="/stats" activeClassName="active">
+          <S.Menu to="/statistic" activeClassName="active">
             통계
           </S.Menu>
 

--- a/src/pages/EventCardListPage/EventCardListPage.jsx
+++ b/src/pages/EventCardListPage/EventCardListPage.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import * as S from './EventCardListPage.style';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router-dom';
 import { axiosInstance } from '@/axios';
 import { EventCard, Dropdown, TopNavigation, Search } from '@/components';
 import { PageLayout } from '@/Layout';

--- a/src/pages/EventCardListPage/EventCardListPage.jsx
+++ b/src/pages/EventCardListPage/EventCardListPage.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import * as S from './EventCardListPage.style';
-// import { USER_ID } from '@/constants';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { axiosInstance } from '@/axios';
 import { EventCard, Dropdown, TopNavigation, Search } from '@/components';
 import { PageLayout } from '@/Layout';
@@ -9,8 +9,10 @@ const EventCardListPage = () => {
   const USER_ID = sessionStorage.getItem('id');
   const [events, setEvents] = useState([]);
   const [filteredEvents, setFilteredEvents] = useState([]);
-  const [selectedFilter, setSelectedFilter] = useState('전체');
   const [searchTerm, setSearchTerm] = useState('');
+
+  const [searchParams, setSearchParams] = useSearchParams();
+  const selectedFilter = searchParams.get('status') || '전체'; // 기본값이 전체
 
   useEffect(() => {
     const fetchData = async () => {
@@ -34,7 +36,7 @@ const EventCardListPage = () => {
               ? new Date() > new Date(endDate)
                 ? '마감'
                 : '진행중'
-              : '진행중', // 현재 날짜와 비교해 상태 결정
+              : '진행중',
           };
         });
 
@@ -52,7 +54,7 @@ const EventCardListPage = () => {
       }
     };
     fetchData();
-  }, []);
+  }, [USER_ID]);
 
   useEffect(() => {
     const filtered = events.filter((event) => {
@@ -68,7 +70,7 @@ const EventCardListPage = () => {
   }, [selectedFilter, events, searchTerm]);
 
   const handleFilterChange = (filter) => {
-    setSelectedFilter(filter);
+    setSearchParams({ status: filter });
   };
 
   const handleSearch = (searchTerm) => {
@@ -81,7 +83,7 @@ const EventCardListPage = () => {
         <div style={{ display: 'flex', justifyContent: 'space-between' }}>
           <Dropdown
             items={['전체', '진행중', '마감']}
-            defaultItem="전체"
+            defaultItem={selectedFilter}
             onSelect={handleFilterChange}
           />
           <Search onSearch={handleSearch} />

--- a/src/router.js
+++ b/src/router.js
@@ -53,11 +53,11 @@ const router = createBrowserRouter([
         element: <DashboardAttendeePage />,
       },
       {
-        path: '/event/dashboard/stats',
+        path: '/event/dashboard/statistic',
         element: <DashboardStatisticPage />,
       },
       {
-        path: '/stats',
+        path: '/statistic',
         element: <TotalStatisticsPage />,
       },
       {

--- a/src/router.js
+++ b/src/router.js
@@ -33,7 +33,7 @@ const router = createBrowserRouter([
         element: <RegisterCompleted />,
       },
       {
-        path: '/event',
+        path: '/events',
         element: <EventCardListPage />,
       },
       {


### PR DESCRIPTION
## #️⃣ 관련 이슈

#235

<br>

## 📝 작업 내용

- 전체, 진행중, 종료를 쿼리로 구현 (새로 고침시 필터 기능 초기화 되는 문제 개선)

<br>

## 📸 스크린샷

|     행사 목록 (전체)     |
| :----------------------: |
| <img width='600' src='https://github.com/user-attachments/assets/6e54895c-bd06-4b03-b45a-71fdb8362567'> |


|     행사 목록 (진행중)     |
| :----------------------: |
| <img width='600' src='https://github.com/user-attachments/assets/b3441a11-3779-43a5-abc3-a358dd274160'> |

|     행사 목록 (종료)     |
| :----------------------: |
| <img width='600' src='https://github.com/user-attachments/assets/6ea25411-4801-48e1-a87d-a21fb003cc29'> |


<br>
