### PR TITLE
#309 feat: 안내 메일 동의 칸 구현

### DIFF
--- a/src/pages/RegisterPage/PageComponents/RegisterPage.style.js
+++ b/src/pages/RegisterPage/PageComponents/RegisterPage.style.js
@@ -141,3 +141,28 @@ export const MainButton = styled.button`
     color: #f2f2f2;
   }
 `;
+
+export const Callout = styled.div`
+  display: flex;
+  align-items: center;
+  border: none;
+  border-radius: 8px;
+  background-color: #f8f8f8;
+  padding: 14px 18px;
+  width: 100%;
+  font-size: 14px;
+  color: #000;
+  outline: none;
+  transition: border-color 0.3s ease;
+  box-sizing: border-box;
+  gap: 10px;
+
+  &::placeholder {
+    color: #aaa;
+  }
+`;
+
+export const CheckBox = styled.input`
+  width: 18px;
+  height: 18px;
+`;

--- a/src/pages/RegisterPage/PageComponents/RegisterSecond.jsx
+++ b/src/pages/RegisterPage/PageComponents/RegisterSecond.jsx
@@ -47,6 +47,7 @@ const RegisterSecond = () => {
     useRecoilState(minCompletionTimes);
   const [eventSchedules, setEventSchedules] = useRecoilState(eventScheduleList);
   const [eventAddress, setEventAddress] = useState('');
+  const [isChecked, setIsChecked] = useState(false);
 
   const navigate = useNavigate();
   const resetAllStates = useResetAllStates();
@@ -66,6 +67,10 @@ const RegisterSecond = () => {
 
   const handleSelect = (value) => {
     setMinCompletionTimesValue(value);
+  };
+
+  const handleCheckboxChange = (event) => {
+    setIsChecked(event.target.checked);
   };
 
   const handleDownload = async (e) => {
@@ -140,6 +145,8 @@ const RegisterSecond = () => {
       completionTimes: minCompletionTimesValue,
       eventSchedules: formatSchedules(eventSchedules),
       eventUrl: eventAddress,
+      alarmRequest: isChecked,
+      alarmResponse: isChecked,
     };
 
     formData.append('eventDetail', JSON.stringify(event));
@@ -152,11 +159,12 @@ const RegisterSecond = () => {
           'Content-Type': 'multipart/form-data',
         },
       });
-      setShowModal(true);
+      alert('행사가 등록되었습니다!');
     } catch (error) {
       alert('행사가 제대로 등록되지 않았습니다.');
       navigate('/register');
     } finally {
+      setShowModal(true);
       setStep(1);
       resetAllStates();
     }
@@ -242,6 +250,18 @@ const RegisterSecond = () => {
                 value={eventAddress}
                 onChange={(e) => setEventAddress(e.target.value)}
               />
+            </S.ContentWrapper>
+
+            <S.ContentWrapper>
+              <S.MainTitle>안내 메일 발송 여부</S.MainTitle>
+              <S.Callout>
+                <S.CheckBox
+                  type="checkbox"
+                  checked={isChecked}
+                  onChange={handleCheckboxChange}
+                />
+                <S.SubTitle>안내 메일 발송에 동의합니다.</S.SubTitle>
+              </S.Callout>
             </S.ContentWrapper>
 
             <S.ButtonWrapper>

--- a/src/pages/registerPage/PageComponents/RegisterSecond.jsx
+++ b/src/pages/registerPage/PageComponents/RegisterSecond.jsx
@@ -47,6 +47,7 @@ const RegisterSecond = () => {
     useRecoilState(minCompletionTimes);
   const [eventSchedules, setEventSchedules] = useRecoilState(eventScheduleList);
   const [eventAddress, setEventAddress] = useState('');
+  const [isChecked, setIsChecked] = useState(false);
 
   const navigate = useNavigate();
   const resetAllStates = useResetAllStates();
@@ -66,6 +67,10 @@ const RegisterSecond = () => {
 
   const handleSelect = (value) => {
     setMinCompletionTimesValue(value);
+  };
+
+  const handleCheckboxChange = (event) => {
+    setIsChecked(event.target.checked);
   };
 
   const handleDownload = async (e) => {
@@ -140,6 +145,8 @@ const RegisterSecond = () => {
       completionTimes: minCompletionTimesValue,
       eventSchedules: formatSchedules(eventSchedules),
       eventUrl: eventAddress,
+      alarmRequest: isChecked,
+      alarmResponse: isChecked,
     };
 
     formData.append('eventDetail', JSON.stringify(event));
@@ -152,11 +159,12 @@ const RegisterSecond = () => {
           'Content-Type': 'multipart/form-data',
         },
       });
-      setShowModal(true);
+      alert('행사가 등록되었습니다!');
     } catch (error) {
       alert('행사가 제대로 등록되지 않았습니다.');
       navigate('/register');
     } finally {
+      setShowModal(true);
       setStep(1);
       resetAllStates();
     }
@@ -242,6 +250,18 @@ const RegisterSecond = () => {
                 value={eventAddress}
                 onChange={(e) => setEventAddress(e.target.value)}
               />
+            </S.ContentWrapper>
+
+            <S.ContentWrapper>
+              <S.MainTitle>안내 메일 발송 여부</S.MainTitle>
+              <S.Callout>
+                <S.CheckBox
+                  type="checkbox"
+                  checked={isChecked}
+                  onChange={handleCheckboxChange}
+                />
+                <S.SubTitle>안내 메일 발송에 동의합니다.</S.SubTitle>
+              </S.Callout>
             </S.ContentWrapper>
 
             <S.ButtonWrapper>


### PR DESCRIPTION
## #️⃣ 관련 이슈

#309

<br>

## 📝 작업 내용

- 안내 메일 동의 칸 구현

<br>

## 📸 스크린샷

|     PC사이즈내용입력     |
| :----------------------: |
| ![image](https://github.com/user-attachments/assets/e19a7a9e-dff9-4b62-a95d-1715c644e112) |

|   모바일사이즈내용입력   |   모바일사이즈내용입력   |
| :----------------------: | :----------------------: |
| <img width='250' src=''> | <img width='250' src=''> |

<br>
