### PR TITLE
#315 feat: `이메일 예약 발송`, `설문조사 링크 발송` 페이지 UI 수정 및 API 연동

### DIFF
--- a/src/components/Button/Button.style.jsx
+++ b/src/components/Button/Button.style.jsx
@@ -13,8 +13,13 @@ export const Button = styled.button`
   font-size: 16px;
   font-weight: 600;
 
-  @media (max-width: ${BREAKPOINTS[0]}px) {
+  @media (max-width: ${BREAKPOINTS[1]}px) {
     padding: 10px 18px;
-    font-size: 14px;
+    height: 35px;
+    font-size: 12px;
+  }
+  @media (max-width: ${BREAKPOINTS[0]}px) {
+    padding: 6px 10px;
+    height: 30px;
   }
 `;

--- a/src/components/Button/Button.style.jsx
+++ b/src/components/Button/Button.style.jsx
@@ -7,6 +7,7 @@ export const Button = styled.button`
   align-items: center;
   border-radius: 8px;
   padding: 13px 22px;
+  height: 45px;
   background: ${(props) => props.backgroundColor};
   color: ${(props) => props.textColor};
   font-size: 16px;

--- a/src/pages/DashboardPage/DashboardEmailPage/DashboardEmailPage.jsx
+++ b/src/pages/DashboardPage/DashboardEmailPage/DashboardEmailPage.jsx
@@ -15,7 +15,7 @@ export default function DashboardEmailPage() {
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
-    const fetchEmailContent = async () => {
+    const getEmailContent = async () => {
       try {
         const response = await axiosInstance.get(
           `/api/v1/events/mail/content/${eventId}`,
@@ -37,14 +37,21 @@ export default function DashboardEmailPage() {
       }
     };
 
-    fetchEmailContent();
+    getEmailContent();
   }, [eventId]);
 
+  // 메일 제목 수정 핸들러
+  const handleTitleChange = (e) => {
+    const newEmailTitle = e.target.value;
+    setEmailTitle(newEmailTitle);
+    setIsModified(newEmailTitle !== '' || emailContent !== '');
+  };
+
+  // 메일 내용 수정 핸들러
   const handleTextareaChange = (e) => {
     const newEmailContent = e.target.value;
-
     setEmailContent(newEmailContent);
-    setIsModified(newEmailContent !== '');
+    setIsModified(newEmailContent !== '' || emailTitle !== '');
   };
 
   // 저장하기 버튼
@@ -56,6 +63,10 @@ export default function DashboardEmailPage() {
     try {
       const response = await axiosInstance.put(
         `/api/v1/events/mail/content/${eventId}`,
+        {
+          mailTitle: emailTitle,
+          mailContent: emailContent,
+        },
       );
 
       if (response.status === 200) {
@@ -106,6 +117,7 @@ export default function DashboardEmailPage() {
             <Input
               placeholder="행사 안내 메일 제목을 작성해 주세요."
               value={emailTitle}
+              onChange={handleTitleChange}
             />
           </S.Content>
 

--- a/src/pages/DashboardPage/DashboardEmailPage/DashboardEmailPage.jsx
+++ b/src/pages/DashboardPage/DashboardEmailPage/DashboardEmailPage.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { PageLayout } from '@/Layout';
 import * as S from './DashboardEmailPage.style';
-import { Sidebar, Button, TopNavigation, Textarea } from '@/components';
+import { Sidebar, Button, TopNavigation, Textarea, Input } from '@/components';
 import { useRecoilValue } from 'recoil';
 import { eventDetail, eventIDState } from '@/recoil/atoms/state';
 import { axiosInstance } from '@/axios';
@@ -77,34 +77,46 @@ export default function DashboardEmailPage() {
     >
       <S.DashboardEmailPage>
         <S.TopContainer>
-          <S.Title>리마인드 메일 발송</S.Title>
+          <S.Content>
+            <S.Title>리마인드 메일 발송</S.Title>
+            <S.ContentDesc>
+              <em>행사 시작 24시간 전</em>에 참석자들에게 발송 될&nbsp;
+              <em>행사 안내 메일 내용</em>을 수정해 주세요.
+            </S.ContentDesc>
+          </S.Content>
           <S.ButtonContainer>
             <Button
               label={isSaving ? '저장 중...' : '저장하기'}
               onClick={handleSaveButtonClick}
+              disabled={!isModified || isSaving}
+              style={{
+                backgroundColor: isModified ? '#007bff' : '#ccc',
+                cursor: isModified ? 'pointer' : 'not-allowed',
+              }}
             />
           </S.ButtonContainer>
         </S.TopContainer>
 
         <S.ContentContainer>
           <S.Content>
-            <S.ContentTitle>리마인드 메일 내용 수정</S.ContentTitle>
-            <S.ContentDesc>
-              <em>행사 시작 24시간 전</em>에 참석자들에게 발송 될&nbsp;
-              <em>행사 안내 메일 내용</em>을 수정해 주세요.
-            </S.ContentDesc>
+            <S.ContentTitle>메일 제목</S.ContentTitle>
+            <Input placeholder="행사 안내 메일 제목을 작성해 주세요." />
           </S.Content>
 
-          {isLoading ? (
-            <p>로딩 중...</p>
-          ) : (
-            <Textarea
-              placeholder="행사 안내 메일 내용을 작성해 주세요."
-              value={emailContent}
-              onChange={handleTextareaChange}
-              height="300px"
-            />
-          )}
+          <S.Content>
+            <S.ContentTitle>메일 내용</S.ContentTitle>
+
+            {isLoading ? (
+              <p>로딩 중...</p>
+            ) : (
+              <Textarea
+                placeholder="행사 안내 메일 내용을 작성해 주세요."
+                value={emailContent}
+                onChange={handleTextareaChange}
+                height="300px"
+              />
+            )}
+          </S.Content>
         </S.ContentContainer>
       </S.DashboardEmailPage>
     </PageLayout>

--- a/src/pages/DashboardPage/DashboardEmailPage/DashboardEmailPage.jsx
+++ b/src/pages/DashboardPage/DashboardEmailPage/DashboardEmailPage.jsx
@@ -8,9 +8,9 @@ import { axiosInstance } from '@/axios';
 
 export default function DashboardEmailPage() {
   const eventId = useRecoilValue(eventIDState) || eventDetail.id;
-  const [surveyUrl, setSurveyUrl] = useState('');
   const [isModified, setIsModified] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
+  const [emailTitle, setEmailTitle] = useState('');
   const [emailContent, setEmailContent] = useState('');
   const [isLoading, setIsLoading] = useState(true);
 
@@ -26,7 +26,9 @@ export default function DashboardEmailPage() {
           },
         );
         if (response.status === 200) {
-          setEmailContent(response.data.content);
+          setEmailContent(response.data.mailContent);
+          setEmailTitle(response.data.mailTitle);
+          console.log(response);
         }
       } catch (error) {
         console.error('이메일 내용 불러오기 실패:', error);
@@ -100,7 +102,10 @@ export default function DashboardEmailPage() {
         <S.ContentContainer>
           <S.Content>
             <S.ContentTitle>메일 제목</S.ContentTitle>
-            <Input placeholder="행사 안내 메일 제목을 작성해 주세요." />
+            <Input
+              placeholder="행사 안내 메일 제목을 작성해 주세요."
+              value={emailTitle}
+            />
           </S.Content>
 
           <S.Content>

--- a/src/pages/DashboardPage/DashboardEmailPage/DashboardEmailPage.jsx
+++ b/src/pages/DashboardPage/DashboardEmailPage/DashboardEmailPage.jsx
@@ -79,13 +79,7 @@ export default function DashboardEmailPage() {
     >
       <S.DashboardEmailPage>
         <S.TopContainer>
-          <S.Content>
-            <S.Title>리마인드 메일 발송</S.Title>
-            <S.ContentDesc>
-              <em>행사 시작 24시간 전</em>에 참석자들에게 발송 될&nbsp;
-              <em>행사 안내 메일 내용</em>을 수정해 주세요.
-            </S.ContentDesc>
-          </S.Content>
+          <S.Title>리마인드 메일 발송</S.Title>
           <S.ButtonContainer>
             <Button
               label={isSaving ? '저장 중...' : '저장하기'}
@@ -100,6 +94,13 @@ export default function DashboardEmailPage() {
         </S.TopContainer>
 
         <S.ContentContainer>
+          <S.Content>
+            <S.ContentTitle>리마인드 메일 내용 수정</S.ContentTitle>
+            <S.ContentDesc>
+              <em>행사 시작 24시간 전</em>에 참석자들에게 발송 될&nbsp;
+              <em>행사 안내 메일 내용</em>을 수정해 주세요.
+            </S.ContentDesc>
+          </S.Content>
           <S.Content>
             <S.ContentTitle>메일 제목</S.ContentTitle>
             <Input

--- a/src/pages/DashboardPage/DashboardSurveyPage/DashboardSurveyPage.jsx
+++ b/src/pages/DashboardPage/DashboardSurveyPage/DashboardSurveyPage.jsx
@@ -54,7 +54,14 @@ export default function DashboardSurveyPage() {
     >
       <S.DashboardSurveyPage>
         <S.TopContainer>
-          <S.Title>설문 조사 링크 발송</S.Title>
+          <S.Content>
+            <S.Title>WISE 설문 조사 링크 발송</S.Title>
+            <S.ContentDesc>
+              <em>행사 종료 1시간 후</em> 참석자들에게 발송 될&nbsp;
+              <em>설문조사 링크</em>를 등록해 주세요. <br /> 링크가 등록되지
+              않으면, 행사 등록 시 입력한 WISE 링크로 대신 발송됩니다.
+            </S.ContentDesc>
+          </S.Content>
           <S.ButtonContainer>
             <Button
               label={isSaving ? '저장 중...' : '저장하기'}
@@ -69,14 +76,6 @@ export default function DashboardSurveyPage() {
         </S.TopContainer>
 
         <S.ContentContainer>
-          <S.Content>
-            <S.ContentTitle>WISE 설문 조사 링크 등록</S.ContentTitle>
-            <S.ContentDesc>
-              <em>행사 종료 1시간 후</em> 참석자들에게 발송 될&nbsp;
-              <em>설문조사 링크</em>를 등록해 주세요. <br /> 링크가 등록되지
-              않으면, 행사 등록 시 입력한 WISE 링크로 대신 발송됩니다.
-            </S.ContentDesc>
-          </S.Content>
           <Input
             placeholder="https://wise.sookmyung.ac.kr/ko/module/eco/@poll/write/4625/0"
             value={surveyUrl}

--- a/src/pages/DashboardPage/DashboardSurveyPage/DashboardSurveyPage.jsx
+++ b/src/pages/DashboardPage/DashboardSurveyPage/DashboardSurveyPage.jsx
@@ -77,14 +77,7 @@ export default function DashboardSurveyPage() {
     >
       <S.DashboardSurveyPage>
         <S.TopContainer>
-          <S.Content>
-            <S.Title>WISE 설문 조사 링크 발송</S.Title>
-            <S.ContentDesc>
-              <em>행사 종료 1시간 후</em> 참석자들에게 발송 될&nbsp;
-              <em>설문조사 링크</em>를 등록해 주세요. <br /> 링크가 등록되지
-              않으면, 행사 등록 시 입력한 WISE 링크로 대신 발송됩니다.
-            </S.ContentDesc>
-          </S.Content>
+          <S.Title>WISE 설문 조사 링크 발송</S.Title>
           <S.ButtonContainer>
             <Button
               label={isSaving ? '저장 중...' : '저장하기'}
@@ -99,11 +92,19 @@ export default function DashboardSurveyPage() {
         </S.TopContainer>
 
         <S.ContentContainer>
-          <Input
-            placeholder="https://wise.sookmyung.ac.kr/ko/module/eco/@poll/write/4625/0"
-            value={surveyUrl}
-            onChange={handleInputChange}
-          />
+          <S.Content>
+            <S.ContentTitle>WISE 설문 조사 링크 등록</S.ContentTitle>
+            <S.ContentDesc>
+              <em>행사 종료 1시간 후</em> 참석자들에게 발송 될&nbsp;
+              <em>설문조사 링크</em>를 등록해 주세요. <br /> 링크가 등록되지
+              않으면, 행사 등록 시 입력한 WISE 링크로 대신 발송됩니다.
+            </S.ContentDesc>
+            <Input
+              placeholder="https://wise.sookmyung.ac.kr/ko/module/eco/@poll/write/4625/0"
+              value={surveyUrl}
+              onChange={handleInputChange}
+            />
+          </S.Content>
         </S.ContentContainer>
       </S.DashboardSurveyPage>
     </PageLayout>

--- a/src/pages/DashboardPage/DashboardSurveyPage/DashboardSurveyPage.jsx
+++ b/src/pages/DashboardPage/DashboardSurveyPage/DashboardSurveyPage.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { PageLayout } from '@/Layout';
 import * as S from './DashboardSurveyPage.style';
 import { Sidebar, Button, TopNavigation, Input } from '@/components';
@@ -12,17 +12,28 @@ export default function DashboardSurveyPage() {
   const [isModified, setIsModified] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
 
-  const handleInputChange = (e) => {
-    const newValue = e.target.value;
-    setSurveyUrl(newValue);
+  // 설문조사 링크 가져오기
+  useEffect(() => {
+    const getSurveyUrl = async () => {
+      try {
+        const response = await axiosInstance.get(
+          `/api/v1/events/survey/${eventId}`,
+        );
 
-    if (newValue !== '') {
-      setIsModified(true);
-    } else {
-      setIsModified(false);
-    }
-  };
+        if (response.status === 200 && response.data) {
+          setSurveyUrl(response.data);
+        } else {
+          console.error(response);
+        }
+      } catch (error) {
+        console.error('설문 조사 링크를 불러오는 중 오류 발생:', error);
+      }
+    };
 
+    getSurveyUrl();
+  }, [eventId]);
+
+  // 설문조사 링크 수정
   const handleSaveButtonClick = async () => {
     if (!isModified) return;
 
@@ -44,6 +55,18 @@ export default function DashboardSurveyPage() {
       alert('설문 조사 링크 저장 중 오류가 발생했습니다.');
     } finally {
       setIsSaving(false);
+    }
+  };
+
+  // 저장하기 버튼
+  const handleInputChange = (e) => {
+    const newValue = e.target.value;
+    setSurveyUrl(newValue);
+
+    if (newValue !== '') {
+      setIsModified(true);
+    } else {
+      setIsModified(false);
     }
   };
 


### PR DESCRIPTION
## #️⃣ 관련 이슈

#315

<br>

## 📝 작업 내용

- `이메일 예약 발송`, `설문조사 링크 발송` 페이지 수정
- 버튼 컴포넌트에 모바일 반응형 적용


<br>

## 📸 스크린샷

|     `이메일 예약 발송` 페이지     |     `설문조사 링크 발송` 페이지     |
| :----------------------: | :----------------------: |
| <img width='600' src='https://github.com/user-attachments/assets/2be4febf-f517-4392-ad41-2fe8f3de09ee'> | <img width='600' src='https://github.com/user-attachments/assets/acb95ab9-e92e-4c80-84f4-dfe4eb5f94b0'> |

<br>
