### PR TITLE
#328 feat: 유저 로그아웃/회원탈퇴 시를 위한 드랍다운 구현

### DIFF
--- a/src/components/TopNavigation/TopNavigation.jsx
+++ b/src/components/TopNavigation/TopNavigation.jsx
@@ -2,16 +2,16 @@ import { useEffect, useState } from 'react';
 import * as S from './TopNavigation.style';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { FaBars, FaCircleUser } from 'react-icons/fa6';
-import { Sidebar, SlimButton } from '@/components';
+import { Sidebar, SlimButton, UserDropdown } from '@/components';
 import { BREAKPOINTS } from '@/styles';
 import { axiosInstance } from '@/axios';
 
 export default function TopNavigation({ eventTitle } = {}) {
   const name = sessionStorage.getItem('name');
-  const USER_ID = sessionStorage.getItem('id');
   const nav = useNavigate();
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
   const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
   const location = useLocation();
 
@@ -29,6 +29,10 @@ export default function TopNavigation({ eventTitle } = {}) {
 
   const toggleSidebar = () => {
     setIsSidebarOpen(!isSidebarOpen);
+  };
+
+  const handleUserControl = () => {
+    setIsDropdownOpen(!isDropdownOpen);
   };
 
   useEffect(() => {
@@ -97,7 +101,12 @@ export default function TopNavigation({ eventTitle } = {}) {
       </S.LogoMenuWrapper>
       <S.ProfileMenuWrapper>
         {isLoggedIn ? (
-          <b onClick={() => handleLogout()}>{name}</b>
+          <>
+            <div onClick={handleUserControl}>
+              {name}
+              {isDropdownOpen && <UserDropdown />}
+            </div>
+          </>
         ) : (
           <SlimButton label={'로그인'} onClick={handleLoginClick} />
         )}

--- a/src/components/UserDropdown/UserDropdown.jsx
+++ b/src/components/UserDropdown/UserDropdown.jsx
@@ -1,0 +1,33 @@
+// 유저 정보 클릭 시 나오는 드랍다운으로 재사용 X
+
+import { axiosInstance } from '@/axios';
+import * as S from './UserDropdown.style';
+import { useNavigate } from 'react-router-dom';
+
+const UserDropdown = () => {
+  const nav = useNavigate();
+
+  const handleLogout = async () => {
+    try {
+      await axiosInstance.get(`/api/v1/logout`);
+      sessionStorage.clear();
+      alert('로그아웃이 완료되었습니다.');
+    } catch (error) {
+      console.log(error);
+    } finally {
+      nav('/');
+      window.location.reload();
+    }
+  };
+
+  return (
+    <S.Dropdown>
+      <S.DropdownContent>
+        <S.DropdownItem onClick={() => handleLogout()}>로그아웃</S.DropdownItem>
+        <S.DropdownItem>회원 탈퇴</S.DropdownItem>
+      </S.DropdownContent>
+    </S.Dropdown>
+  );
+};
+
+export default UserDropdown;

--- a/src/components/UserDropdown/UserDropdown.style.js
+++ b/src/components/UserDropdown/UserDropdown.style.js
@@ -1,0 +1,41 @@
+import styled from 'styled-components';
+
+export const Dropdown = styled.div`
+  position: relative;
+  display: inline-block;
+  transform: translate(-75px, 10px);
+`;
+
+export const DropdownContent = styled.ul`
+  display: flex;
+  flex-direction: column;
+  position: absolute;
+  z-index: 1000;
+  top: 100%;
+  left: 0;
+  margin: 8px 0 0;
+  border: 1px solid var(--blue-4, #accdff);
+  border-radius: 7px;
+  background: #f4f8ff;
+  padding: 4px;
+  min-width: max-content;
+  box-shadow: 4px 4px 4px 0px rgba(0, 0, 0, 0.1);
+  list-style: none;
+`;
+
+export const DropdownItem = styled.li`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 10px 16px;
+  border-radius: 4px;
+
+  font-size: 14px;
+  color: #323232;
+  cursor: pointer;
+
+  &:hover {
+    background: var(--blue-4, #accdff);
+  }
+`;

--- a/src/components/UserDropdown/index.js
+++ b/src/components/UserDropdown/index.js
@@ -1,0 +1,1 @@
+export { default as UserDropdown } from './UserDropdown';

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -21,3 +21,4 @@ export * from './GraphBox';
 export * from './Search';
 export * from './Scheduler';
 export * from './UploadBox';
+export * from './UserDropdown';


### PR DESCRIPTION
## #️⃣ 관련 이슈

#328 

<br>

## 📝 작업 내용

- 기존 (표시된 이름 누르면 바로 로그아웃) 방식에서 드랍다운을 걸쳐 로그아웃할 수 있도록 수정

<br>

## 📸 스크린샷

|     PC사이즈내용입력     |
| :----------------------: |
| ![image](https://github.com/user-attachments/assets/1dee614d-070e-4a4d-a4fe-4eea239aa29c) |

|   모바일사이즈내용입력   |   모바일사이즈내용입력   |
| :----------------------: | :----------------------: |
| <img width='250' src=''> | <img width='250' src=''> |

<br>
