### PR TITLE
#331 fix: 출석 버튼 바로 가기 시 이벤트 id 전달

### DIFF
--- a/src/components/EventCard/EventCard.jsx
+++ b/src/components/EventCard/EventCard.jsx
@@ -15,6 +15,7 @@ const EventCard = ({ id, title, poster, startDate, endDate }) => {
 
   const attendanceCheck = (event) => {
     event.stopPropagation();
+    setContent(id);
     navigate('/attendance/student-id');
   };
 


### PR DESCRIPTION
## #️⃣ 관련 이슈

#331

<br>

## 📝 작업 내용

-출석하러가기 버튼 클릭 시 행사 아이디가 같이 가지 않던 오류 수정

<br>

## 📸 스크린샷

|     PC사이즈내용입력     |
| :----------------------: |
| <img width='600' src=''> |

|   모바일사이즈내용입력   |   모바일사이즈내용입력   |
| :----------------------: | :----------------------: |
| <img width='250' src=''> | <img width='250' src=''> |

<br>
