### PR TITLE
#350 design: 행사 카드 내 이미지와 버튼 사이 간격 조정

### DIFF
--- a/src/components/EventCard/EventCard.style.jsx
+++ b/src/components/EventCard/EventCard.style.jsx
@@ -67,7 +67,6 @@ export const Button = styled.button`
   transition:
     background 0.3s,
     transform 0.3s;
-  margin-top: auto;
   border: none;
   border-radius: 10px;
   width: 100%;


### PR DESCRIPTION
## #️⃣ 관련 이슈

#350

<br>

## 📝 작업 내용

- 행사 카드 내 이미지와 버튼 사이 간격 조정

<br>

## 📸 스크린샷

|     행사 목록 페이지    |
| :----------------------: |
| <img width='600' src='https://github.com/user-attachments/assets/dcabec4d-3e5e-4a8c-8174-88cb11b80c3f'> |

<br>
